### PR TITLE
Remove SecureString and build ManagedSecureCharBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## About
 Secure JSON is a JSON reader and writer that works outside of the garbage-collected heap. It can work on CharSequence
-(including String) or InputStream. Serialization is to a SecureCharBuffer-backed string and is destroyed after it has
-been consumed.
+(including String) or InputStream. Serialization is to a bytebuffer-backed CharSequence and is destroyed immediately
+after it has been consumed.
 
 It is Java 7 and higher compatible (tests run against Java 7, Java 8, and Java 10).
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -39,8 +39,6 @@ sourceSets {
 }
 
 dependencies {
-    compile 'io.github.novacrypto:SecureString:0.1.8@jar'
-    cliCompile 'io.github.novacrypto:SecureString:0.1.8@jar'
     testCompile 'org.testng:testng:6.14.3'
     testRuntime 'org.testng:testng:6.14.3'
 }

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -76,7 +76,7 @@ check.dependsOn jacocoTestReport
 check.dependsOn jacocoTestCoverageVerification
 
 group = 'com.chelseaurquhart'
-def versionNumber = '1.0.2'
+def versionNumber = '1.0.3'
 if (project.hasProperty('release')) {
     version = versionNumber
 } else {

--- a/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
@@ -167,7 +167,7 @@ class JSONReader implements Closeable, AutoCloseable {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         numberReader.close();
         stringReader.close();
     }

--- a/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
@@ -13,6 +13,8 @@ final class JSONSymbolCollection {
     static final short UNICODE_DIGIT_THIRD = UNICODE_DIGITS;
     static final short HEX_MIN_ALPHA = 10;
     static final short HEX_MAX = 15;
+    static final short BITS_IN_BYTE = 8;
+    static final short TWO_BYTE = 255;
 
     static final Map<Character, Character> END_TOKENS = listToMap(
         Token.R_BRACE.getShortSymbol(),

--- a/src/main/java/com/chelseaurquhart/securejson/ManagedSecureBufferList.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ManagedSecureBufferList.java
@@ -1,6 +1,7 @@
 package com.chelseaurquhart.securejson;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,7 +13,7 @@ class ManagedSecureBufferList implements Closeable, AutoCloseable {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         for (final ManagedSecureCharBuffer myBuffer : secureBuffers) {
             myBuffer.close();
         }

--- a/src/main/java/com/chelseaurquhart/securejson/Messages.java
+++ b/src/main/java/com/chelseaurquhart/securejson/Messages.java
@@ -18,7 +18,9 @@ final class Messages {
         ERROR_MALFORMED_NUMBER,
         ERROR_EXTRA_CHARACTERS,
         ERROR_ITERATOR_REMOVE_NOT_ALLOWED,
-        ERROR_INVALID_TYPE
+        ERROR_INVALID_TYPE,
+        ERROR_BAD_SEQUENCE_ARGS,
+        ERROR_BUFFER_OVERFLOW
     }
 
     static String get(final Key parKey) throws IOException {

--- a/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
+++ b/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
@@ -9,8 +9,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * SecureJSON is a JSON serializer and deserializer with strict security in mind. It does not create strings due to
  * their inclusion in garbage collectible heap (which can make them potentially snoopable). See
- * https://medium.com/@_west_on/protecting-strings-in-jvm-memory-84c365f8f01c for the motivations around this. It
- * uses the excellent SecureString library (https://github.com/NovaCrypto/SecureString) for the secure data structures.
+ * https://medium.com/@_west_on/protecting-strings-in-jvm-memory-84c365f8f01c for the motivations around this.
  */
 public final class SecureJSON {
     private SecureJSON() {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -11,3 +11,5 @@ ERROR_MALFORMED_JSON=malformed json
 ERROR_INVALID_TYPE=invalid type
 ERROR_ITERATOR_REMOVE_NOT_ALLOWED=This iterator is read-only.
 ERROR_EMPTY_JSON=Empty JSON string.
+ERROR_BAD_SEQUENCE_ARGS=start must be >=0 and and end >= start
+ERROR_BUFFER_OVERFLOW=buffer overflow detected

--- a/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
@@ -7,7 +7,6 @@ import com.chelseaurquhart.securejson.JSONDecodeException.MalformedListException
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedStringException;
 
 import com.chelseaurquhart.securejson.util.StringUtil;
-import io.github.novacrypto.SecureCharBuffer;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -426,7 +425,7 @@ public final class JSONReaderTest {
         Parameters(final String parTestName, final CharSequence parInputString, final Object parExpected,
                    final Exception parExpectedException) {
             testName = parTestName;
-            final SecureCharBuffer mySecureBuffer = SecureCharBuffer.withCapacity(parInputString.length());
+            final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(parInputString.length());
             mySecureBuffer.append(parInputString);
             inputString = mySecureBuffer;
             expected = parExpected;

--- a/src/test/java/com/chelseaurquhart/securejson/ManagedSecureCharBufferTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/ManagedSecureCharBufferTest.java
@@ -1,0 +1,466 @@
+package com.chelseaurquhart.securejson;
+
+import com.chelseaurquhart.securejson.util.StringUtil;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public final class ManagedSecureCharBufferTest {
+    private static final String SUBSEQUENCE_DATA_PROVIDER_NAME = "ManagedSecureCharBufferTestCharSequence";
+    @DataProvider(name = SUBSEQUENCE_DATA_PROVIDER_NAME)
+    private static Object[] dataProvider(final Method parMethod) {
+        return new Object[]{
+            new Parameters(
+                "simple single byte buffer",
+                4,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                    }
+                },
+                "a",
+                0,
+                1,
+                null
+            ),
+            new Parameters(
+                "simple single string",
+                4,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("ab");
+                    }
+                },
+                "a",
+                0,
+                1,
+                null
+            ),
+            new Parameters(
+                "simple single bytes 1.5x capacity",
+                2,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                    }
+                },
+                "ab",
+                0,
+                2,
+                null
+            ),
+            new Parameters(
+                "simple single bytes 1.5x capacity expect full",
+                2,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                    }
+                },
+                "abc",
+                0,
+                3,
+                null
+            ),
+            new Parameters(
+                "simple single bytes 1.5x capacity expect full - first",
+                2,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                    }
+                },
+                "bc",
+                1,
+                3,
+                null
+            ),
+            new Parameters(
+                "starts in second buffer, consumes middle",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "def",
+                3,
+                6,
+                null
+            ),
+            new Parameters(
+                "starts in second buffer, consumes part of middle",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "de",
+                3,
+                5,
+                null
+            ),
+            new Parameters(
+                "starts in second buffer (last char), consumes next 1",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "f",
+                5,
+                6,
+                null
+            ),
+            new Parameters(
+                "starts in second buffer (last char), consumes next 2",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "fg",
+                5,
+                7,
+                null
+            ),
+            new Parameters(
+                "starts in third buffer (first char), consumes next 1",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "g",
+                6,
+                7,
+                null
+            ),
+            new Parameters(
+                "starts in third buffer (first char), consumes next 2",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append('a');
+                        parInput.append('b');
+                        parInput.append('c');
+                        parInput.append('d');
+                        parInput.append('e');
+                        parInput.append('f');
+                        parInput.append('g');
+                        parInput.append('h');
+                        parInput.append('i');
+                    }
+                },
+                "gh",
+                6,
+                8,
+                null
+            ),
+            new Parameters(
+                "charsequences, 3 buffers, empty middle, consume full",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                        parInput.append("");
+                        parInput.append("c");
+                    }
+                },
+                "ac",
+                0,
+                2,
+                null
+            ),
+            new Parameters(
+                "charsequences, 3 buffers, empty middle, consume first",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                        parInput.append("");
+                        parInput.append("c");
+                    }
+                },
+                "a",
+                0,
+                1,
+                null
+            ),
+            new Parameters(
+                "charsequences, 3 buffers, empty middle, consume last",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                        parInput.append("");
+                        parInput.append("c");
+                    }
+                },
+                "c",
+                1,
+                2,
+                null
+            ),
+            new Parameters(
+                "start == end",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                        parInput.append("");
+                        parInput.append("c");
+                    }
+                },
+                "",
+                1,
+                1,
+                null
+            ),
+            new Parameters(
+                "start < 0",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                    }
+                },
+                "",
+                -1,
+                1,
+                "start must be >=0 and and end >= start"
+            ),
+            new Parameters(
+                "end < start",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                    }
+                },
+                "",
+                1,
+                0,
+                "start must be >=0 and and end >= start"
+            ),
+            new Parameters(
+                "end > total length",
+                3,
+                new IConsumer<ManagedSecureCharBuffer>() {
+                    @Override
+                    public void accept(final ManagedSecureCharBuffer parInput) {
+                        parInput.append("a");
+                    }
+                },
+                "",
+                0,
+                2,
+                "buffer overflow detected"
+            ),
+        };
+    }
+
+    @Test
+    public void testFullBuffer() throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4)) {
+            myManagedSecureCharBuffer.append('t');
+            myManagedSecureCharBuffer.append('e');
+            myManagedSecureCharBuffer.append('s');
+            myManagedSecureCharBuffer.append('t');
+            Assert.assertEquals("test", StringUtil.charSequenceToString(myManagedSecureCharBuffer));
+        }
+    }
+
+    @Test
+    public void testOverflowBuffer() throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4)) {
+            myManagedSecureCharBuffer.append('t');
+            myManagedSecureCharBuffer.append('e');
+            myManagedSecureCharBuffer.append('s');
+            myManagedSecureCharBuffer.append('t');
+            myManagedSecureCharBuffer.append('2');
+            Assert.assertEquals("test2", StringUtil.charSequenceToString(myManagedSecureCharBuffer));
+        }
+    }
+
+    @Test
+    public void testUnderflowBuffer() throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4)) {
+            myManagedSecureCharBuffer.append('t');
+            myManagedSecureCharBuffer.append('e');
+            Assert.assertEquals("te", StringUtil.charSequenceToString(myManagedSecureCharBuffer));
+        }
+    }
+
+    @Test
+    public void testCharSequenceByReference() throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4)) {
+            final MutatableString myCharSequence = new MutatableString();
+
+            myCharSequence.string = "TEST";
+            myManagedSecureCharBuffer.append(myCharSequence);
+
+            Assert.assertEquals(StringUtil.charSequenceToString(myManagedSecureCharBuffer), "TEST");
+            myCharSequence.string = "TEST2";
+            Assert.assertEquals(StringUtil.charSequenceToString(myManagedSecureCharBuffer), "TEST2");
+        }
+    }
+
+    @Test
+    public void testCharSequenceAndBytesMixedClose() throws IOException {
+        final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4);
+
+        myManagedSecureCharBuffer.append('a');
+        myManagedSecureCharBuffer.append('b');
+        myManagedSecureCharBuffer.append("test");
+        myManagedSecureCharBuffer.append('c');
+        myManagedSecureCharBuffer.append("test2");
+        myManagedSecureCharBuffer.append('d');
+
+        Assert.assertEquals(StringUtil.charSequenceToString(myManagedSecureCharBuffer), "abtestctest2d");
+        myManagedSecureCharBuffer.close();
+        // after closing all should be empty
+        Assert.assertEquals(StringUtil.charSequenceToString(myManagedSecureCharBuffer), "");
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testToStringException() throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = new ManagedSecureCharBuffer(4)) {
+            myManagedSecureCharBuffer.append('a');
+            myManagedSecureCharBuffer.append('b');
+            myManagedSecureCharBuffer.toString();
+        }
+    }
+
+    @Test(dataProvider = SUBSEQUENCE_DATA_PROVIDER_NAME)
+    public void testSubSequence(final Parameters parParameters) throws IOException {
+        try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = parParameters.managedSecureCharBuffer) {
+            try {
+                final CharSequence mySequence = myManagedSecureCharBuffer.subSequence(
+                    parParameters.start, parParameters.end);
+                Assert.assertEquals(StringUtil.charSequenceToString(mySequence), parParameters.expected);
+                Assert.assertNull(parParameters.expectedException);
+            } catch (final Exception myException) {
+                Assert.assertNotNull(parParameters.expectedException);
+                Assert.assertEquals(myException.getMessage(), parParameters.expectedException);
+            }
+        }
+    }
+
+    private static class MutatableString implements CharSequence {
+        private String string;
+
+        @Override
+        public int length() {
+            return string.length();
+        }
+
+        @Override
+        public char charAt(final int parIndex) {
+            return string.charAt(parIndex);
+        }
+
+        @Override
+        public CharSequence subSequence(final int parStart, final int parEnd) {
+            return string.subSequence(parStart, parEnd);
+        }
+    }
+
+    private static final class Parameters {
+        private String testName;
+        private ManagedSecureCharBuffer managedSecureCharBuffer;
+        private CharSequence expected;
+        private int start;
+        private int end;
+        private String expectedException;
+
+        private Parameters(final String parTestName, final int parCapacity,
+                           final IConsumer<ManagedSecureCharBuffer> parManagedSecureCharBufferConsumer,
+                           final CharSequence parExpected, final int parStart, final int parEnd,
+                           final String parExpectedException) {
+            testName = parTestName;
+            managedSecureCharBuffer = new ManagedSecureCharBuffer(parCapacity);
+            parManagedSecureCharBufferConsumer.accept(managedSecureCharBuffer);
+            expected = parExpected;
+            start = parStart;
+            end = parEnd;
+            expectedException = parExpectedException;
+        }
+
+        @Override
+        public String toString() {
+            return testName;
+        }
+    }
+}

--- a/src/test/java/com/chelseaurquhart/securejson/NumberProvider.java
+++ b/src/test/java/com/chelseaurquhart/securejson/NumberProvider.java
@@ -2,7 +2,6 @@ package com.chelseaurquhart.securejson;
 
 import  com.chelseaurquhart.securejson.JSONDecodeException.MalformedNumberException;
 
-import io.github.novacrypto.SecureCharBuffer;
 import org.testng.annotations.DataProvider;
 
 import java.io.IOException;
@@ -522,7 +521,7 @@ public final class NumberProvider {
             return null;
         }
 
-        final SecureCharBuffer mySecureBuffer = SecureCharBuffer.withCapacity(parInput.length());
+        final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(parInput.length());
         mySecureBuffer.append(parInput);
 
         return mySecureBuffer;

--- a/src/test/java/com/chelseaurquhart/securejson/StringProvider.java
+++ b/src/test/java/com/chelseaurquhart/securejson/StringProvider.java
@@ -1,6 +1,5 @@
 package com.chelseaurquhart.securejson;
 
-import io.github.novacrypto.SecureCharBuffer;
 import org.testng.annotations.DataProvider;
 
 import java.lang.reflect.Method;
@@ -54,7 +53,7 @@ public final class StringProvider {
             return null;
         }
 
-        final SecureCharBuffer mySecureBuffer = SecureCharBuffer.withCapacity(parInput.length());
+        final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(parInput.length());
         mySecureBuffer.append(parInput);
 
         return mySecureBuffer;


### PR DESCRIPTION
This is mostly because of SecureString not being in Maven Central, but also to create a buffer that does less copying.