### PR TITLE
Reader/SecureJSON refactor

### DIFF
--- a/src/main/java/com/chelseaurquhart/securejson/IReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/IReader.java
@@ -1,11 +1,12 @@
 package com.chelseaurquhart.securejson;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
  * @exclude
  */
-interface IReader {
+interface IReader<T> extends Closeable {
     Object normalizeCollection(Object parValue);
 
     /**
@@ -18,11 +19,13 @@ interface IReader {
         RESERVED
     }
 
-    Object read(ICharacterIterator parIterator) throws IOException;
+    T read(ICharacterIterator parIterator) throws IOException;
 
     void addValue(ICharacterIterator parIterator, Object parCollection, Object parValue) throws IOException;
 
     boolean isStart(ICharacterIterator parIterator) throws IOException;
+
+    boolean isContainerType();
 
     SymbolType getSymbolType(ICharacterIterator parIterator) throws IOException;
 }

--- a/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
@@ -19,11 +19,17 @@ final class JSONSymbolCollection {
     static final short BITS_IN_BYTE = 8;
     static final short TWO_BYTE = 255;
 
-    static final Map<Character, Character> END_TOKENS = listToMap(
-        Token.R_BRACE.getShortSymbol(),
-        Token.R_CURLY.getShortSymbol(),
-        Token.QUOTE.getShortSymbol(),
-        Token.COMMA.getShortSymbol()
+    static final Map<Character, Token> END_TOKENS = listToMap(
+        Token.R_BRACE,
+        Token.R_CURLY,
+        Token.QUOTE,
+        Token.COMMA
+    );
+
+    static final Map<Character, Token> WORD_TOKENS = listToMap(
+        Token.NULL,
+        Token.TRUE,
+        Token.FALSE
     );
 
     static final Map<Character, Character> WHITESPACES = listToMap(
@@ -34,35 +40,44 @@ final class JSONSymbolCollection {
         '\u0009'
     );
 
-    static final Map<Character, Character> TOKENS = listToMap(
-        Token.L_BRACE.getShortSymbol(),
-        Token.R_BRACE.getShortSymbol(),
-        Token.L_CURLY.getShortSymbol(),
-        Token.R_CURLY.getShortSymbol(),
-        Token.COLON.getShortSymbol(),
-        Token.QUOTE.getShortSymbol(),
-        Token.COMMA.getShortSymbol(),
-        Token.NULL.getShortSymbol(),
-        Token.FALSE.getShortSymbol(),
-        Token.TRUE.getShortSymbol()
+    static final Map<Character, Token> TOKENS = listToMap(
+        Token.L_BRACE,
+        Token.R_BRACE,
+        Token.L_CURLY,
+        Token.R_CURLY,
+        Token.COLON,
+        Token.QUOTE,
+        Token.COMMA,
+        Token.NULL,
+        Token.FALSE,
+        Token.TRUE
     );
 
-    static final Map<Character, Character> NUMBERS = listToMap(
-        Token.ZERO.getShortSymbol(),
-        Token.ONE.getShortSymbol(),
-        Token.TWO.getShortSymbol(),
-        Token.THREE.getShortSymbol(),
-        Token.FOUR.getShortSymbol(),
-        Token.FIVE.getShortSymbol(),
-        Token.SIX.getShortSymbol(),
-        Token.SEVEN.getShortSymbol(),
-        Token.EIGHT.getShortSymbol(),
-        Token.NINE.getShortSymbol(),
-        Token.DECIMAL.getShortSymbol(),
-        Token.MINUS.getShortSymbol(),
-        Token.PLUS.getShortSymbol(),
-        Token.EXPONENT.getShortSymbol()
+    static final Map<Character, Token> NUMBERS = listToMap(
+        Token.ZERO,
+        Token.ONE,
+        Token.TWO,
+        Token.THREE,
+        Token.FOUR,
+        Token.FIVE,
+        Token.SIX,
+        Token.SEVEN,
+        Token.EIGHT,
+        Token.NINE,
+        Token.DECIMAL,
+        Token.MINUS,
+        Token.PLUS,
+        Token.EXPONENT
     );
+
+    private static Map<Character, Token> listToMap(final Token... parElements) {
+        final Map<Character, Token> myMap = new HashMap<>();
+        for (final Token myElement : parElements) {
+            myMap.put(myElement.getShortSymbol(), myElement);
+        }
+
+        return Collections.unmodifiableMap(myMap);
+    }
 
     private static Map<Character, Character> listToMap(final Character... parElements) {
         final Map<Character, Character> myMap = new HashMap<>();

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * @exclude
  */
-class ListReader implements IReader {
+class ListReader implements IReader<ListReader.Container> {
     private final JSONReader jsonReader;
 
     ListReader(final JSONReader parJsonReader) {
@@ -76,11 +76,20 @@ class ListReader implements IReader {
         return parValue;
     }
 
+    @Override
+    public boolean isContainerType() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+    }
+
     private Container objectToContainer(final Object parValue) {
         return (Container) parValue;
     }
 
-    private static final class Container {
+    static final class Container {
         private List<Object> list;
 
         private Container() {
@@ -98,5 +107,4 @@ class ListReader implements IReader {
             return list;
         }
     }
-
 }

--- a/src/main/java/com/chelseaurquhart/securejson/MapReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/MapReader.java
@@ -9,11 +9,11 @@ import java.util.Map;
 /**
  * @exclude
  */
-class MapReader implements IReader {
+class MapReader implements IReader<MapReader.Container> {
     private final JSONReader jsonReader;
-    private final StringReader stringReader;
+    private final IReader<CharSequence> stringReader;
 
-    MapReader(final JSONReader parJsonReader, final StringReader parStringReader) {
+    MapReader(final JSONReader parJsonReader, final IReader<CharSequence> parStringReader) {
         jsonReader = parJsonReader;
         stringReader = parStringReader;
     }
@@ -43,7 +43,7 @@ class MapReader implements IReader {
     }
 
     @Override
-    public MapReader.Container read(final ICharacterIterator parIterator) throws IOException {
+    public Container read(final ICharacterIterator parIterator) throws IOException {
         if (parIterator.peek() != JSONSymbolCollection.Token.L_CURLY.getShortSymbol()) {
             throw new MalformedMapException(parIterator);
         }
@@ -87,6 +87,16 @@ class MapReader implements IReader {
         return parValue;
     }
 
+    @Override
+    public boolean isContainerType() {
+        return true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        stringReader.close();
+    }
+
     private CharSequence readKey(final ICharacterIterator parIterator) throws IOException {
         final CharSequence myKey = stringReader.read(parIterator);
         jsonReader.moveToNextToken(parIterator);
@@ -107,7 +117,7 @@ class MapReader implements IReader {
         return (Container) parValue;
     }
 
-    private static final class Container {
+    static final class Container {
         private Map<CharSequence, Object> map;
         private CharSequence key;
 

--- a/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
@@ -13,7 +13,7 @@ import java.util.Map;
 /**
  * @exclude
  */
-class NumberReader extends ManagedSecureBufferList implements IReader {
+class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
     static final MathContext DEFAULT_MATH_CONTEXT = new MathContext(MathContext.DECIMAL64.getPrecision(),
         RoundingMode.UNNECESSARY);
 
@@ -117,6 +117,11 @@ class NumberReader extends ManagedSecureBufferList implements IReader {
     @Override
     public Object normalizeCollection(final Object parValue) {
         return parValue;
+    }
+
+    @Override
+    public boolean isContainerType() {
+        return false;
     }
 
     Map.Entry<BigDecimal, Boolean> charSequenceToBigDecimal(final CharSequence parSource, final int parOffset)

--- a/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
+++ b/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 /**
  * SecureJSON is a JSON serializer and deserializer with strict security in mind. It does not create strings due to
@@ -61,6 +62,8 @@ public final class SecureJSON {
      */
     public void toJSON(final Object parInput, final IConsumer<CharSequence> parConsumer)
             throws JSONEncodeException {
+        Objects.requireNonNull(parConsumer);
+
         try (final JSONWriter myJsonWriter = new JSONWriter(new ObjectWriter(), settings)) {
             parConsumer.accept(myJsonWriter.write(parInput));
         } catch (final JSONEncodeException myException) {
@@ -98,6 +101,8 @@ public final class SecureJSON {
      */
     public void toJSONBytes(final Object parInput, final IConsumer<byte[]> parConsumer)
             throws JSONEncodeException {
+        Objects.requireNonNull(parConsumer);
+
         try (final JSONWriter myJsonWriter = new JSONWriter(new ObjectWriter(), settings)) {
             parConsumer.accept(myJsonWriter.write(parInput).getBytes());
         } catch (final JSONEncodeException myException) {
@@ -125,8 +130,9 @@ public final class SecureJSON {
      * @param parOutputStream The stream to write to.
      * @throws JSONEncodeException On encode failure.
      */
-    public void toJSON(final Object parInput, final OutputStream parOutputStream)
-            throws JSONEncodeException {
+    public void toJSON(final Object parInput, final OutputStream parOutputStream) throws JSONEncodeException {
+        Objects.requireNonNull(parOutputStream);
+
         try (final JSONWriter myJsonWriter = new JSONWriter(new ObjectWriter(), settings)) {
             myJsonWriter.write(parInput, new OutputStreamWriter(parOutputStream, StandardCharsets.UTF_8));
         } catch (final JSONEncodeException myException) {
@@ -167,6 +173,9 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final CharSequence parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
+        Objects.requireNonNull(parInput);
+        Objects.requireNonNull(parConsumer);
+
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
         } catch (final JSONDecodeException myException) {
@@ -250,6 +259,9 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final byte[] parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
+        Objects.requireNonNull(parInput);
+        Objects.requireNonNull(parConsumer);
+
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(new ByteArrayInputStream(parInput)));
         } catch (final JSONDecodeException myException) {
@@ -299,6 +311,10 @@ public final class SecureJSON {
      */
     public <T> void fromJSON(final byte[] parInput, final IConsumer<T> parConsumer, final Class<T> parClass)
             throws JSONDecodeException {
+        Objects.requireNonNull(parInput);
+        Objects.requireNonNull(parConsumer);
+        Objects.requireNonNull(parClass);
+
         fromJSON(parInput, getConsumer(parConsumer, parClass));
     }
 
@@ -334,6 +350,9 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final InputStream parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
+        Objects.requireNonNull(parInput);
+        Objects.requireNonNull(parConsumer);
+
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
         } catch (final JSONDecodeException myException) {
@@ -383,10 +402,16 @@ public final class SecureJSON {
      */
     public <T> void fromJSON(final InputStream parInput, final IConsumer<T> parConsumer, final Class<T> parClass)
             throws JSONDecodeException {
+        Objects.requireNonNull(parInput);
+        Objects.requireNonNull(parConsumer);
+        Objects.requireNonNull(parClass);
+
         fromJSON(parInput, getConsumer(parConsumer, parClass));
     }
 
     private <T> IConsumer<?> getConsumer(final IConsumer<T> parConsumer, final Class<T> parClass) {
+        Objects.requireNonNull(parConsumer);
+
         if (parClass == null) {
             return parConsumer;
         }
@@ -541,7 +566,7 @@ public final class SecureJSON {
          */
         public Builder writableCharBufferFactory(
                 final IFunction<Integer, IWritableCharSequence> parWritableCharBufferFactory) {
-            writableCharBufferFactory = parWritableCharBufferFactory;
+            writableCharBufferFactory = Objects.requireNonNull(parWritableCharBufferFactory);
 
             return this;
         }

--- a/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
+++ b/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
@@ -167,7 +167,7 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final CharSequence parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
-        try (final JSONReader myJsonReader = new JSONReader(settings)) {
+        try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
         } catch (final JSONDecodeException myException) {
             throw myException;
@@ -250,7 +250,7 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final byte[] parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
-        try (final JSONReader myJsonReader = new JSONReader(settings)) {
+        try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(new ByteArrayInputStream(parInput)));
         } catch (final JSONDecodeException myException) {
             throw myException;
@@ -334,7 +334,7 @@ public final class SecureJSON {
      */
     @SuppressWarnings("unchecked")
     public <T> void fromJSON(final InputStream parInput, final IConsumer<T> parConsumer) throws JSONDecodeException {
-        try (final JSONReader myJsonReader = new JSONReader(settings)) {
+        try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
         } catch (final JSONDecodeException myException) {
             throw myException;

--- a/src/main/java/com/chelseaurquhart/securejson/StringReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/StringReader.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 /**
  * @exclude
  */
-class StringReader extends ManagedSecureBufferList implements IReader {
+class StringReader extends ManagedSecureBufferList implements IReader<CharSequence> {
     private static final int TWO_DIGIT_MIN = 10;
 
     private final Settings settings;
@@ -82,6 +82,11 @@ class StringReader extends ManagedSecureBufferList implements IReader {
     @Override
     public Object normalizeCollection(final Object parValue) {
         return parValue;
+    }
+
+    @Override
+    public boolean isContainerType() {
+        return false;
     }
 
     private char readUnicode(final ICharacterIterator parInput) throws IOException {

--- a/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
@@ -22,30 +22,39 @@ import java.util.HashMap;
 
 public final class JSONReaderTest {
     @Test(dataProviderClass = NumberProvider.class, dataProvider = NumberProvider.DATA_PROVIDER_NAME)
-    public void testReadNumberFromString(final NumberProvider.Parameters parParameters) throws IOException {
-        final JSONReader myReader = new JSONReader(new NumberReader(parParameters.mathContext, Settings.DEFAULTS),
-            Settings.DEFAULTS);
+    public void testReadNumberFromString(final NumberProvider.Parameters parParameters) {
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS)
+            .numberReader(new NumberReader(parParameters.mathContext, Settings.DEFAULTS))
+            .build();
 
         runTest(myReader, parParameters.number, parParameters.expected, parParameters.expectedException);
     }
 
     @Test(dataProviderClass = NumberProvider.class, dataProvider = NumberProvider.DATA_PROVIDER_NAME)
-    public void testReadNumberFromStream(final NumberProvider.Parameters parParameters) throws IOException {
-        final JSONReader myReader = new JSONReader(new NumberReader(parParameters.mathContext, Settings.DEFAULTS),
-            Settings.DEFAULTS);
+    public void testReadNumberFromStream(final NumberProvider.Parameters parParameters) {
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS)
+            .numberReader(new NumberReader(parParameters.mathContext, Settings.DEFAULTS))
+            .build();
+
         runTest(myReader, inputToStream(parParameters.number, null), parParameters.expected,
             parParameters.expectedException);
     }
 
     @Test(dataProviderClass = StringProvider.class, dataProvider = StringProvider.DATA_PROVIDER_NAME)
-    public void testReadStringFromString(final StringProvider.Parameters parParameters) throws IOException {
-        final JSONReader myReader = new JSONReader(new StringReader(Settings.DEFAULTS), Settings.DEFAULTS);
+    public void testReadStringFromString(final StringProvider.Parameters parParameters) {
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS)
+            .stringReader(new StringReader(Settings.DEFAULTS))
+            .build();
+
         runTest(myReader, parParameters.inputString, parParameters.expected, parParameters.expectedException);
     }
 
     @Test(dataProviderClass = StringProvider.class, dataProvider = StringProvider.DATA_PROVIDER_NAME)
-    public void testReadStringFromStream(final StringProvider.Parameters parParameters) throws IOException {
-        final JSONReader myReader = new JSONReader(new StringReader(Settings.DEFAULTS), Settings.DEFAULTS);
+    public void testReadStringFromStream(final StringProvider.Parameters parParameters) {
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS)
+            .stringReader(new StringReader(Settings.DEFAULTS))
+            .build();
+
         runTest(myReader, inputToStream(parParameters.inputString, null), parParameters.expected,
             parParameters.expectedException);
     }
@@ -358,7 +367,7 @@ public final class JSONReaderTest {
     }
 
     @Test(dataProvider = DATA_PROVIDER_NAME)
-    public void testReadGenericFromString(final Parameters parParameters) throws IOException {
+    public void testReadGenericFromString(final Parameters parParameters) {
         if (parParameters.inputBytes != null) {
             final char[] myChars = new char[parParameters.inputBytes.length];
             for (int myIndex = myChars.length - 1; myIndex >= 0; myIndex--) {
@@ -367,14 +376,14 @@ public final class JSONReaderTest {
             parParameters.inputString = new String(myChars);
         }
 
-        final JSONReader myReader = new JSONReader(Settings.DEFAULTS);
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS).build();
         runTest(myReader, parParameters.inputString, parParameters.expected,
             parParameters.expectedException);
     }
 
     @Test(dataProvider = DATA_PROVIDER_NAME)
-    public void testReadGenericFromStream(final Parameters parParameters) throws IOException {
-        final JSONReader myReader = new JSONReader(Settings.DEFAULTS);
+    public void testReadGenericFromStream(final Parameters parParameters) {
+        final JSONReader myReader = new JSONReader.Builder(Settings.DEFAULTS).build();
 
         runTest(myReader, inputToStream(parParameters.inputString, parParameters.inputBytes), parParameters.expected,
             parParameters.expectedException);


### PR DESCRIPTION
- JSONReader now uses generic readers, simplifying the reader logic a little bit
- JSONReader now uses Builder pattern and unused args are removed
- make IReader have a type specifically because MapReader requires StringReader
- remove unthrown exceptions from signatures
- add Objects.requireNonNull
- add type to all readers (WordReader is explicitly Object to simplify it)
- simplify WordReader a bit further by adding a list of word tokens
- store Token objects in collections instead of Character (still keep Character as map key for efficient lookups)
- add null checks to public SecureJSON interface to abort early on unusable inputs