### PR TITLE
Minor optimizations and improvements

### DIFF
--- a/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
+++ b/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
@@ -16,6 +16,8 @@
 
 package com.chelseaurquhart.securejson;
 
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
+
 /**
  * Circular array queue. Has optimizations to prevent math if size is 1.
  *
@@ -35,7 +37,7 @@ class CharQueue {
     void add(final char parChar) {
         if (capacity == 1) {
             if (writeIndex != 0) {
-                throw new IllegalStateException();
+                throw new JSONRuntimeException(new IllegalStateException());
             }
             chars[0] = parChar;
             writeIndex = 1;
@@ -43,7 +45,7 @@ class CharQueue {
         }
 
         if (readIndex == (writeIndex + 1) % chars.length) {
-            throw new IllegalStateException();
+            throw new JSONRuntimeException(new IllegalStateException());
         }
 
         chars[writeIndex] = parChar;
@@ -52,7 +54,7 @@ class CharQueue {
 
     char pop() {
         if (isEmpty()) {
-            throw new IllegalStateException();
+            throw new JSONRuntimeException(new IllegalStateException());
         }
 
         final char myRes = chars[readIndex];
@@ -70,7 +72,7 @@ class CharQueue {
 
     char peek() {
         if (isEmpty()) {
-            throw new IllegalStateException();
+            throw new JSONRuntimeException(new IllegalStateException());
         }
 
         return chars[readIndex];

--- a/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
+++ b/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Chelsea Urquhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chelseaurquhart.securejson;
+
+/**
+ * Circular array queue.
+ *
+ * @exclude
+ */
+class CharQueue {
+    private char[] chars;
+    private int readIndex = 0;
+    private int writeIndex = 0;
+
+    CharQueue(final int parCapacity) {
+        chars = new char[parCapacity + 1];
+    }
+
+    void add(final char parChar) {
+        if (readIndex == (writeIndex + 1) % chars.length) {
+            throw new IllegalStateException();
+        }
+
+        chars[writeIndex] = parChar;
+        writeIndex = (writeIndex + 1) % chars.length;
+    }
+
+    char pop() {
+        if (isEmpty()) {
+            throw new IllegalStateException();
+        }
+
+        final char myRes = chars[readIndex];
+        chars[readIndex] = '\u0000';
+        readIndex = (readIndex + 1) % chars.length;
+
+        return myRes;
+    }
+
+    char peek() {
+        if (isEmpty()) {
+            throw new IllegalStateException();
+        }
+
+        return chars[readIndex];
+    }
+
+    int size() {
+        return Math.abs(readIndex - writeIndex);
+    }
+
+    boolean isEmpty() {
+        return readIndex == writeIndex;
+    }
+}

--- a/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
+++ b/src/main/java/com/chelseaurquhart/securejson/CharQueue.java
@@ -17,7 +17,7 @@
 package com.chelseaurquhart.securejson;
 
 /**
- * Circular array queue.
+ * Circular array queue. Has optimizations to prevent math if size is 1.
  *
  * @exclude
  */
@@ -25,12 +25,23 @@ class CharQueue {
     private char[] chars;
     private int readIndex = 0;
     private int writeIndex = 0;
+    private int capacity;
 
     CharQueue(final int parCapacity) {
-        chars = new char[parCapacity + 1];
+        capacity = parCapacity;
+        chars = new char[parCapacity];
     }
 
     void add(final char parChar) {
+        if (capacity == 1) {
+            if (writeIndex != 0) {
+                throw new IllegalStateException();
+            }
+            chars[0] = parChar;
+            writeIndex = 1;
+            return;
+        }
+
         if (readIndex == (writeIndex + 1) % chars.length) {
             throw new IllegalStateException();
         }
@@ -46,6 +57,12 @@ class CharQueue {
 
         final char myRes = chars[readIndex];
         chars[readIndex] = '\u0000';
+
+        if (capacity == 1) {
+            writeIndex = 0;
+            return myRes;
+        }
+
         readIndex = (readIndex + 1) % chars.length;
 
         return myRes;
@@ -60,10 +77,18 @@ class CharQueue {
     }
 
     int size() {
+        if (capacity == 1) {
+            return writeIndex;
+        }
+
         return Math.abs(readIndex - writeIndex);
     }
 
     boolean isEmpty() {
         return readIndex == writeIndex;
+    }
+
+    int capacity() {
+        return capacity;
     }
 }

--- a/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
+++ b/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
@@ -21,8 +21,6 @@ import com.chelseaurquhart.securejson.JSONDecodeException.MalformedJSONException
 import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.NoSuchElementException;
 
 /**
@@ -43,7 +41,7 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
     private static final char UTF_LITTLE_ENDIAN = '\ufffe';
 
 
-    private final Deque<Character> charQueue;
+    private final CharQueue charQueue;
     private int offset;
     private boolean initialized;
     private Encoding encoding;
@@ -54,7 +52,7 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
 
     EncodingAwareCharacterIterator(final int parOffset) {
         offset = parOffset;
-        charQueue = new ArrayDeque<>();
+        charQueue = new CharQueue(UTF32_BYTES);
     }
 
     @Override

--- a/src/main/java/com/chelseaurquhart/securejson/IWritableCharSequence.java
+++ b/src/main/java/com/chelseaurquhart/securejson/IWritableCharSequence.java
@@ -36,6 +36,8 @@ public interface IWritableCharSequence extends CharSequence, Closeable, AutoClos
      * Check if this buffer is restricted to the initial capacity. If it is, we will create more buffers before going
      * over the initial capacity. If it is not, we will expect it to handle resizing itself.
      *
+     * Note that the result of this will be cached. Changing values at runtime is not supported.
+     *
      * @return True if this buffer is restricted to the initial capacity. False otherwise.
      */
     boolean isRestrictedToCapacity();

--- a/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
@@ -182,7 +182,7 @@ final class JSONReader implements Closeable, AutoCloseable {
 
     void moveToNextToken(final ICharacterIterator parIterator) throws IOException {
         while (parIterator.hasNext()) {
-            final char myChar = Character.toLowerCase(parIterator.peek());
+            final char myChar = parIterator.peek();
             if (JSONSymbolCollection.WHITESPACES.containsKey(myChar)) {
                 parIterator.next();
             } else if (isValidToken(myChar)) {

--- a/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
@@ -203,7 +203,7 @@ final class JSONSymbolCollection {
             return symbol;
         }
 
-        Character getShortSymbol() {
+        char getShortSymbol() {
             return shortSymbol;
         }
     }

--- a/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
@@ -142,13 +142,16 @@ final class JSONSymbolCollection {
         FORM_FEED('\f', "\\f"),
         BACKSPACE('\b', "\\b"),
         UNICODE('u'),
-        ESCAPE('\\', "\\\\");
+        ESCAPE('\\', "\\\\"),
+        UNKNOWN(null, null);
 
         private static final Map<Character, Token> SHORT_TOKEN_MAP = new HashMap<>();
 
         static {
             for (final Token myValue : values()) {
-                SHORT_TOKEN_MAP.put(myValue.getShortSymbol(), myValue);
+                if (myValue != UNKNOWN) {
+                    SHORT_TOKEN_MAP.put(myValue.getShortSymbol(), myValue);
+                }
             }
         }
 
@@ -185,8 +188,10 @@ final class JSONSymbolCollection {
             this.value = parValue;
             if (symbol instanceof Character) {
                 this.shortSymbol = (char) symbol;
-            } else {
+            } else if (symbol != null) {
                 this.shortSymbol = symbol.toString().charAt(0);
+            } else {
+                this.shortSymbol = '\u0000';
             }
         }
 

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -34,7 +34,8 @@ class ListReader implements IReader<ListReader.Container> {
 
     @Override
     public boolean isStart(final ICharacterIterator parIterator) throws IOException {
-        return JSONSymbolCollection.Token.L_BRACE.getShortSymbol().equals(parIterator.peek());
+        return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+            == JSONSymbolCollection.Token.L_BRACE;
     }
 
     @Override
@@ -58,7 +59,8 @@ class ListReader implements IReader<ListReader.Container> {
 
     @Override
     public Container read(final ICharacterIterator parIterator) throws IOException {
-        if (!JSONSymbolCollection.Token.L_BRACE.getShortSymbol().equals(parIterator.peek())) {
+        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+                != JSONSymbolCollection.Token.L_BRACE) {
             throw new MalformedListException(parIterator);
         }
 

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -43,15 +43,17 @@ class ListReader implements IReader<ListReader.Container> {
             throw new MalformedListException(parIterator);
         }
 
-        final char myChar = parIterator.peek();
+        final JSONSymbolCollection.Token myToken = JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(),
+            JSONSymbolCollection.Token.UNKNOWN);
 
-        if (myChar == JSONSymbolCollection.Token.R_BRACE.getShortSymbol()) {
-            return SymbolType.END;
-        } else if (myChar == JSONSymbolCollection.Token.COMMA.getShortSymbol()) {
-            return SymbolType.SEPARATOR;
+        switch (myToken) {
+            case R_BRACE:
+                return SymbolType.END;
+            case COMMA:
+                return SymbolType.SEPARATOR;
+            default:
+                return SymbolType.UNKNOWN;
         }
-
-        return SymbolType.UNKNOWN;
     }
 
     @Override

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -59,11 +59,6 @@ class ListReader implements IReader<ListReader.Container> {
 
     @Override
     public Container read(final ICharacterIterator parIterator) throws IOException {
-        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
-                != JSONSymbolCollection.Token.L_BRACE) {
-            throw new MalformedListException(parIterator);
-        }
-
         parIterator.next();
         jsonReader.moveToNextToken(parIterator);
 

--- a/src/main/java/com/chelseaurquhart/securejson/ManagedSecureCharBuffer.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ManagedSecureCharBuffer.java
@@ -25,6 +25,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @exclude
@@ -33,8 +34,8 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
     private static final int INITIAL_CAPACITY = 32;
 
     private final int initialCapacity;
-    private final LinkedList<CharSequence> buffers;
-    private final LinkedList<IWritableCharSequence> writeBuffers;
+    private final List<CharSequence> buffers;
+    private final List<IWritableCharSequence> writeBuffers;
     private byte[] bytes;
     private final Settings settings;
     private Capacity capacityRestriction;
@@ -56,8 +57,8 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
         capacityRestriction = Capacity.UNKNOWN;
     }
 
-    private ManagedSecureCharBuffer(final int parInitialCapacity, final LinkedList<CharSequence> parBuffers,
-                                    final LinkedList<IWritableCharSequence> parWriteBuffers,
+    private ManagedSecureCharBuffer(final int parInitialCapacity, final List<CharSequence> parBuffers,
+                                    final List<IWritableCharSequence> parWriteBuffers,
                                     final Settings parSettings) {
         initialCapacity = parInitialCapacity;
         buffers = parBuffers;

--- a/src/main/java/com/chelseaurquhart/securejson/ManagedSecureCharBuffer.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ManagedSecureCharBuffer.java
@@ -31,12 +31,14 @@ import java.util.LinkedList;
  */
 final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSequence, ICharacterWriter {
     private static final int INITIAL_CAPACITY = 32;
-    private static final int HASH_PRIME = 31;
 
     private final int initialCapacity;
     private final LinkedList<CharSequence> buffers;
+    private final LinkedList<IWritableCharSequence> writeBuffers;
     private byte[] bytes;
     private final Settings settings;
+    private Capacity capacityRestriction;
+    private IWritableCharSequence writeBuffer;
 
     ManagedSecureCharBuffer(final Settings parSettings) {
         this(0, parSettings);
@@ -49,52 +51,54 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
             initialCapacity = INITIAL_CAPACITY;
         }
         buffers = new LinkedList<>();
+        writeBuffers = new LinkedList<>();
         settings = parSettings;
+        capacityRestriction = Capacity.UNKNOWN;
     }
 
     private ManagedSecureCharBuffer(final int parInitialCapacity, final LinkedList<CharSequence> parBuffers,
+                                    final LinkedList<IWritableCharSequence> parWriteBuffers,
                                     final Settings parSettings) {
         initialCapacity = parInitialCapacity;
         buffers = parBuffers;
+        writeBuffers = parWriteBuffers;
         settings = parSettings;
+        capacityRestriction = Capacity.UNKNOWN;
     }
 
     @Override
     public void append(final char parChar) throws IOException {
         final int myMaxSize = initialCapacity + 1;
 
-        final CharSequence myHeadBuffer;
-        if (buffers.isEmpty()) {
-            myHeadBuffer = null;
-        } else {
-            myHeadBuffer = buffers.getLast();
+        if (writeBuffer == null || (capacityRestriction == Capacity.RESTRICTED
+                && writeBuffer.length() + 1 >= (writeBuffer).getCapacity())) {
+            writeBuffer = settings.getWritableCharBufferFactory().accept(myMaxSize);
+            if (writeBuffer.isRestrictedToCapacity()) {
+                capacityRestriction = Capacity.RESTRICTED;
+            } else {
+                capacityRestriction = Capacity.UNRESTRICTED;
+            }
+            buffers.add(writeBuffer);
+            writeBuffers.add(writeBuffer);
         }
 
-        final CharSequence myWriteBuffer;
-        if (!(myHeadBuffer instanceof IWritableCharSequence)
-                || (myHeadBuffer.length() + 1 >= ((IWritableCharSequence) myHeadBuffer).getCapacity()
-                && ((IWritableCharSequence) myHeadBuffer).isRestrictedToCapacity())) {
-            myWriteBuffer = settings.getWritableCharBufferFactory().accept(myMaxSize);
-            buffers.add(myWriteBuffer);
-        } else {
-            myWriteBuffer = myHeadBuffer;
-        }
-        ((IWritableCharSequence) myWriteBuffer).append(parChar);
+        writeBuffer.append(parChar);
     }
 
     @Override
     public void append(final CharSequence parChars) {
         buffers.add(parChars);
+        // we'll need a new buffer or we'll get out of order.
+        writeBuffer = null;
     }
 
     @Override
     public void close() throws IOException {
-        for (final CharSequence myBuffer : buffers) {
-            if (myBuffer instanceof Closeable) {
-                ((Closeable) myBuffer).close();
-            }
+        for (final IWritableCharSequence myBuffer : writeBuffers) {
+            myBuffer.close();
         }
         buffers.clear();
+        writeBuffers.clear();
         closeBytes();
     }
 
@@ -213,7 +217,7 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
             throw new ArrayIndexOutOfBoundsException(myMessage);
         }
 
-        return new ManagedSecureCharBuffer(initialCapacity, myBuffers, settings);
+        return new ManagedSecureCharBuffer(initialCapacity, myBuffers, writeBuffers, settings);
     }
 
     @Override
@@ -226,51 +230,6 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
             Arrays.fill(bytes, (byte) 0);
             bytes = null;
         }
-    }
-
-    @Override
-    public boolean equals(final Object parObject) {
-        if (this == parObject) {
-            return true;
-        }
-        if (!(parObject instanceof CharSequence)) {
-            return false;
-        }
-
-        return isEqual(subSequence(0, length()), (CharSequence) parObject);
-    }
-
-    @Override
-    public int hashCode() {
-        return hashCode(subSequence(0, length()));
-    }
-
-    private static boolean isEqual(final CharSequence parLhs, final CharSequence parRhs) {
-        if (parLhs == null || parRhs == null) {
-            return parLhs == parRhs;
-        }
-
-        final int myLength = parLhs.length();
-        if (parRhs.length() != myLength) {
-            return false;
-        }
-
-        for (int myIndex = 0; myIndex < myLength; myIndex++) {
-            if (parLhs.charAt(myIndex) != parRhs.charAt(myIndex)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static int hashCode(final CharSequence parSubSequence) {
-        int myHashCode = 0;
-        for (int myIndex = parSubSequence.length() - 1; myIndex > 0; myIndex--) {
-            myHashCode += HASH_PRIME * (int) parSubSequence.charAt(myIndex);
-        }
-
-        return myHashCode;
     }
 
     /**
@@ -351,23 +310,6 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
         }
 
         @Override
-        public boolean equals(final Object parObject) {
-            if (this == parObject) {
-                return true;
-            }
-            if (!(parObject instanceof CharSequence)) {
-                return false;
-            }
-
-            return isEqual(subSequence(0, length()), (CharSequence) parObject);
-        }
-
-        @Override
-        public int hashCode() {
-            return ManagedSecureCharBuffer.hashCode(subSequence(0, length()));
-        }
-
-        @Override
         public String toString() {
             throw new UnsupportedOperationException();
         }
@@ -381,5 +323,11 @@ final class ManagedSecureCharBuffer implements Closeable, AutoCloseable, CharSeq
         public int getCapacity() {
             return capacity;
         }
+    }
+
+    private enum Capacity {
+        UNKNOWN,
+        RESTRICTED,
+        UNRESTRICTED
     }
 }

--- a/src/main/java/com/chelseaurquhart/securejson/MapReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/MapReader.java
@@ -45,17 +45,19 @@ class MapReader implements IReader<MapReader.Container> {
             throw new MalformedMapException(parIterator);
         }
 
-        final char myChar = parIterator.peek();
+        final JSONSymbolCollection.Token myToken = JSONSymbolCollection.Token.forSymbolOrDefault(
+            parIterator.peek(), JSONSymbolCollection.Token.UNKNOWN);
 
-        if (myChar == JSONSymbolCollection.Token.R_CURLY.getShortSymbol()) {
-            return SymbolType.END;
-        } else if (myChar == JSONSymbolCollection.Token.COLON.getShortSymbol()) {
-            return SymbolType.SEPARATOR;
-        } else if (myChar == JSONSymbolCollection.Token.COMMA.getShortSymbol()) {
-            return SymbolType.RESERVED;
+        switch (myToken) {
+            case R_CURLY:
+                return SymbolType.END;
+            case COLON:
+                return SymbolType.SEPARATOR;
+            case COMMA:
+                return SymbolType.RESERVED;
+            default:
+                return SymbolType.UNKNOWN;
         }
-
-        return SymbolType.UNKNOWN;
     }
 
     @Override
@@ -71,7 +73,8 @@ class MapReader implements IReader<MapReader.Container> {
             throw new MalformedMapException(parIterator);
         }
 
-        if (JSONSymbolCollection.Token.R_CURLY.getShortSymbol().equals(parIterator.peek())) {
+        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+                == JSONSymbolCollection.Token.R_CURLY) {
             return new Container(null);
         } else {
             return new Container(readKey(parIterator));

--- a/src/main/java/com/chelseaurquhart/securejson/MapReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/MapReader.java
@@ -63,11 +63,6 @@ class MapReader implements IReader<MapReader.Container> {
 
     @Override
     public Container read(final ICharacterIterator parIterator) throws IOException {
-        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
-                != JSONSymbolCollection.Token.L_CURLY) {
-            throw new MalformedMapException(parIterator);
-        }
-
         parIterator.next();
         jsonReader.moveToNextToken(parIterator);
 

--- a/src/main/java/com/chelseaurquhart/securejson/MapReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/MapReader.java
@@ -36,7 +36,8 @@ class MapReader implements IReader<MapReader.Container> {
 
     @Override
     public boolean isStart(final ICharacterIterator parIterator) throws IOException {
-        return JSONSymbolCollection.Token.L_CURLY.getShortSymbol().equals(parIterator.peek());
+        return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+            == JSONSymbolCollection.Token.L_CURLY;
     }
 
     @Override
@@ -62,7 +63,8 @@ class MapReader implements IReader<MapReader.Container> {
 
     @Override
     public Container read(final ICharacterIterator parIterator) throws IOException {
-        if (!JSONSymbolCollection.Token.L_CURLY.getShortSymbol().equals(parIterator.peek())) {
+        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+                != JSONSymbolCollection.Token.L_CURLY) {
             throw new MalformedMapException(parIterator);
         }
 
@@ -119,7 +121,8 @@ class MapReader implements IReader<MapReader.Container> {
     private CharSequence readKey(final ICharacterIterator parIterator) throws IOException {
         final CharSequence myKey = stringReader.read(parIterator);
         jsonReader.moveToNextToken(parIterator);
-        if (!JSONSymbolCollection.Token.COLON.getShortSymbol().equals(parIterator.peek())) {
+        if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+                != JSONSymbolCollection.Token.COLON) {
             throw new MalformedMapException(parIterator);
         }
         parIterator.next();

--- a/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
@@ -192,16 +192,20 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
             } else {
                 myNextChar = 0;
             }
+            final JSONSymbolCollection.Token myNextToken = JSONSymbolCollection.Token.forSymbolOrDefault(
+                myNextChar, JSONSymbolCollection.Token.UNKNOWN);
+            final JSONSymbolCollection.Token myLastToken = JSONSymbolCollection.Token.forSymbolOrDefault(
+                myLastChar, JSONSymbolCollection.Token.UNKNOWN);
 
             switch (myToken) {
                 case ZERO:
                     if (myLength != 1 && !myFoundNonZeroDigit && !myFoundDecimal) {
                         if (myLength <= myIndex + 1) {
-                            if (myLastChar != JSONSymbolCollection.Token.MINUS.getShortSymbol()) {
+                            if (myLastToken != JSONSymbolCollection.Token.MINUS) {
                                 throw buildException(parSource, myIndex + parOffset);
                             }
-                        } else if (myNextChar != JSONSymbolCollection.Token.DECIMAL.getShortSymbol()
-                                && myNextChar != JSONSymbolCollection.Token.EXPONENT.getShortSymbol()) {
+                        } else if (myNextToken != JSONSymbolCollection.Token.DECIMAL
+                                && myNextToken != JSONSymbolCollection.Token.EXPONENT) {
                             throw buildException(parSource, myIndex + parOffset + 1);
                         }
                     }
@@ -225,18 +229,18 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
                     myForceDouble = true;
                     break;
                 case EXPONENT:
-                    if (myFoundExponent || myLastChar == JSONSymbolCollection.Token.DECIMAL.getShortSymbol()
+                    if (myFoundExponent || myLastToken == JSONSymbolCollection.Token.DECIMAL
                             || myIndex == myLength - 1 || myIndex == 0) {
                         throw buildException(parSource, myIndex + parOffset);
                     }
                     myFoundExponent = true;
-                    if (myNextChar == JSONSymbolCollection.Token.MINUS.getShortSymbol()) {
+                    if (myNextToken == JSONSymbolCollection.Token.MINUS) {
                         myForceDouble = true;
-                        parBuffer[++myIndex + myLengthOffset] = JSONSymbolCollection.Token.MINUS.getShortSymbol();
+                        parBuffer[++myIndex + myLengthOffset] = myNextChar;
                         if (myIndex == myLength - 1) {
                             throw buildException(parSource, myIndex + parOffset);
                         }
-                    } else if (myNextChar == JSONSymbolCollection.Token.PLUS.getShortSymbol()) {
+                    } else if (myNextToken == JSONSymbolCollection.Token.PLUS) {
                         myIndex++;
                         if (myIndex == myLength - 1) {
                             throw buildException(parSource, myIndex + parOffset);
@@ -249,8 +253,8 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
                         throw buildException(parSource, myIndex + parOffset);
                     }
 
-                    if (myNextChar == JSONSymbolCollection.Token.DECIMAL.getShortSymbol()
-                            || myNextChar == JSONSymbolCollection.Token.EXPONENT.getShortSymbol()) {
+                    if (myNextToken == JSONSymbolCollection.Token.DECIMAL
+                            || myNextToken == JSONSymbolCollection.Token.EXPONENT) {
                         throw buildException(parSource, myIndex + parOffset + 1);
                     } else if (myIndex == 0) {
                         // 0 is ok, anything else is not.

--- a/src/main/java/com/chelseaurquhart/securejson/StringReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/StringReader.java
@@ -35,7 +35,8 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
 
     @Override
     public boolean isStart(final ICharacterIterator parIterator) throws IOException {
-        return JSONSymbolCollection.Token.QUOTE.getShortSymbol().equals(parIterator.peek());
+        return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
+            == JSONSymbolCollection.Token.QUOTE;
     }
 
     @Override
@@ -46,7 +47,7 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
     @Override
     public CharSequence read(final ICharacterIterator parInput)
             throws IOException {
-        if (!JSONSymbolCollection.Token.QUOTE.getShortSymbol().equals(parInput.peek())) {
+        if (JSONSymbolCollection.Token.forSymbolOrDefault(parInput.peek(), null) != JSONSymbolCollection.Token.QUOTE) {
             throw new MalformedStringException(parInput);
         }
         parInput.next();
@@ -56,6 +57,8 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
 
         while (parInput.hasNext()) {
             char myChar = parInput.next();
+            final JSONSymbolCollection.Token myToken = JSONSymbolCollection.Token.forSymbolOrDefault(myChar,
+                JSONSymbolCollection.Token.UNKNOWN);
             if (myChar == '\\') {
                 if (!parInput.hasNext()) {
                     throw new MalformedStringException(parInput);
@@ -83,7 +86,7 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
             } else if (myChar < JSONSymbolCollection.MIN_ALLOWED_ASCII_CODE) {
                 throw new MalformedUnicodeValueException(parInput);
             } else {
-                if (myChar == JSONSymbolCollection.Token.QUOTE.getShortSymbol()) {
+                if (myToken == JSONSymbolCollection.Token.QUOTE) {
                     return mySecureBuffer;
                 }
                 mySecureBuffer.append(myChar);

--- a/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
@@ -47,7 +47,7 @@ public final class CharQueueTest {
 
     @Test
     public void testWrapping() {
-        final CharQueue myQueue = new CharQueue(4);
+        final CharQueue myQueue = new CharQueue(5);
         myQueue.add('a');
         myQueue.add('b');
         myQueue.add('c');

--- a/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Chelsea Urquhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chelseaurquhart.securejson;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public final class CharQueueTest {
+    private CharQueueTest() {
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testAddBufferOverflow() {
+        final CharQueue myQueue = new CharQueue(4);
+        myQueue.add('a');
+        myQueue.add('b');
+        myQueue.add('c');
+        myQueue.add('d');
+        myQueue.add('e');
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testPopBufferUnderflow() {
+        final CharQueue myQueue = new CharQueue(4);
+        myQueue.pop();
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testPeekBufferUnderflow() {
+        final CharQueue myQueue = new CharQueue(4);
+        myQueue.peek();
+    }
+
+    @Test
+    public void testWrapping() {
+        final CharQueue myQueue = new CharQueue(4);
+        myQueue.add('a');
+        myQueue.add('b');
+        myQueue.add('c');
+        myQueue.add('d');
+        Assert.assertEquals(myQueue.peek(), 'a');
+        Assert.assertEquals(myQueue.pop(), 'a');
+        myQueue.add('e');
+        Assert.assertEquals(myQueue.pop(), 'b');
+        Assert.assertEquals(myQueue.pop(), 'c');
+        Assert.assertEquals(myQueue.pop(), 'd');
+        Assert.assertEquals(myQueue.pop(), 'e');
+        Assert.assertTrue(myQueue.isEmpty());
+    }
+}

--- a/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
@@ -16,6 +16,8 @@
 
 package com.chelseaurquhart.securejson;
 
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -23,7 +25,7 @@ public final class CharQueueTest {
     private CharQueueTest() {
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = JSONRuntimeException.class)
     public void testAddBufferOverflow() {
         final CharQueue myQueue = new CharQueue(4);
         myQueue.add('a');
@@ -33,13 +35,13 @@ public final class CharQueueTest {
         myQueue.add('e');
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = JSONRuntimeException.class)
     public void testPopBufferUnderflow() {
         final CharQueue myQueue = new CharQueue(4);
         myQueue.pop();
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test(expectedExceptions = JSONRuntimeException.class)
     public void testPeekBufferUnderflow() {
         final CharQueue myQueue = new CharQueue(4);
         myQueue.peek();

--- a/src/test/java/com/chelseaurquhart/securejson/ManagedSecureCharBufferTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/ManagedSecureCharBufferTest.java
@@ -458,9 +458,9 @@ public final class ManagedSecureCharBufferTest {
     public void testEqual(final Parameters parParameters) throws IOException {
         try (final ManagedSecureCharBuffer myManagedSecureCharBuffer = parParameters.managedSecureCharBuffer) {
             if (parParameters.expectedEquals) {
-                Assert.assertTrue(myManagedSecureCharBuffer.equals(parParameters.expected));
+                Assert.assertTrue(isEqual(myManagedSecureCharBuffer, parParameters.expected));
             } else {
-                Assert.assertFalse(myManagedSecureCharBuffer.equals(parParameters.expected));
+                Assert.assertFalse(isEqual(myManagedSecureCharBuffer, parParameters.expected));
             }
         }
     }
@@ -492,6 +492,25 @@ public final class ManagedSecureCharBufferTest {
         public CharSequence subSequence(final int parStart, final int parEnd) {
             return string.subSequence(parStart, parEnd);
         }
+    }
+
+    static boolean isEqual(final CharSequence parLhs, final CharSequence parRhs) {
+        if (parLhs == null || parRhs == null) {
+            return parLhs == parRhs;
+        }
+
+        final int myLength = parLhs.length();
+        if (parRhs.length() != myLength) {
+            return false;
+        }
+
+        for (int myIndex = 0; myIndex < myLength; myIndex++) {
+            if (parLhs.charAt(myIndex) != parRhs.charAt(myIndex)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static final class Parameters {


### PR DESCRIPTION
Note that most of these are very, very minor optimizations, and some are just code improvements.

- reduce getShortSymbol calls by looking up enum value first
- add CharQueue (specialized circular character queue with additional optimization for single chars) to reduce queue overhead
- don't bother checking first char in map/list read. It gets checked in reader.
- don't convert to lowercase when iterating tokens
- get rid of equals and hashCode in MCB, they're only needed in tests so the code should be there
- improve append
- cache result of isRestrictedToCapacity