### PR TITLE
resolve json exception too many parents errors in sonarqube

### DIFF
--- a/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
+++ b/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
@@ -68,6 +68,7 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our integer value.
      *
      * @return An integer representation of our value.
+     * @throws JSONRuntimeException On error.
      */
     @Override
     public final int intValue() {
@@ -77,7 +78,7 @@ public class HugeDecimal extends Number implements CharSequence {
 
         try {
             return numberReader.charSequenceToBigDecimal(chars, 0).getKey().intValue();
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             throw new JSONRuntimeException(myException);
         }
     }
@@ -86,6 +87,7 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our long value.
      *
      * @return A long representation of our value.
+     * @throws JSONRuntimeException On error.
      */
     @Override
     public final long longValue() {
@@ -95,7 +97,7 @@ public class HugeDecimal extends Number implements CharSequence {
 
         try {
             return numberReader.charSequenceToBigDecimal(chars, 0).getKey().longValue();
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             throw new JSONRuntimeException(myException);
         }
     }
@@ -104,6 +106,7 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our float value.
      *
      * @return A float representation of our value.
+     * @throws JSONRuntimeException On error.
      */
     @Override
     public final float floatValue() {
@@ -113,7 +116,7 @@ public class HugeDecimal extends Number implements CharSequence {
 
         try {
             return numberReader.charSequenceToBigDecimal(chars, 0).getKey().floatValue();
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             throw new JSONRuntimeException(myException);
         }
     }
@@ -122,6 +125,7 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our double value.
      *
      * @return A double representation of our value.
+     * @throws JSONRuntimeException On error.
      */
     @Override
     public final double doubleValue() {
@@ -131,7 +135,7 @@ public class HugeDecimal extends Number implements CharSequence {
 
         try {
             return numberReader.charSequenceToBigDecimal(chars, 0).getKey().doubleValue();
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             throw new JSONRuntimeException(myException);
         }
     }
@@ -153,9 +157,10 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our value converted to a BigInteger.
      *
      * @return a BigInteger representation of our character sequence.
-     * @throws IOException On error.
+     * @throws IOException On IO error with resource file.
+     * @throws JSONException On sequence read failure.
      */
-    public final BigInteger bigIntegerValue() throws IOException {
+    public final BigInteger bigIntegerValue() throws IOException, JSONException {
         if (number != null) {
             if (number instanceof BigInteger) {
                 return (BigInteger) number;
@@ -175,9 +180,10 @@ public class HugeDecimal extends Number implements CharSequence {
      * Get our value converted to a BigDecimal.
      *
      * @return a BigDecimal representation of our character sequence.
-     * @throws IOException On error.
+     * @throws IOException On IO error with resource file.
+     * @throws JSONException On sequence read failure.
      */
-    public final BigDecimal bigDecimalValue() throws IOException {
+    public final BigDecimal bigDecimalValue() throws IOException, JSONException {
         if (number != null) {
             if (number instanceof BigDecimal) {
                 return (BigDecimal) number;
@@ -216,7 +222,7 @@ public class HugeDecimal extends Number implements CharSequence {
         } else {
             try {
                 return bigDecimalValue().equals(myThat.bigDecimalValue());
-            } catch (final IOException myException) {
+            } catch (final IOException | JSONException myException) {
                 throw new JSONRuntimeException(myException);
             }
         }

--- a/src/main/java/com/chelseaurquhart/securejson/ICharacterIterator.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ICharacterIterator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
  * @exclude
  */
 interface ICharacterIterator extends Iterator<Character> {
-    Character peek() throws IOException;
+    Character peek() throws IOException, JSONException;
 
     int getOffset();
 }

--- a/src/main/java/com/chelseaurquhart/securejson/IReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/IReader.java
@@ -35,13 +35,14 @@ interface IReader<T> extends Closeable {
         RESERVED
     }
 
-    T read(ICharacterIterator parIterator) throws IOException;
+    T read(ICharacterIterator parIterator) throws IOException, JSONException;
 
-    void addValue(ICharacterIterator parIterator, Object parCollection, Object parValue) throws IOException;
+    void addValue(ICharacterIterator parIterator, Object parCollection, Object parValue) throws IOException,
+        JSONException;
 
-    boolean isStart(ICharacterIterator parIterator) throws IOException;
+    boolean isStart(ICharacterIterator parIterator) throws IOException, JSONException;
 
     boolean isContainerType();
 
-    SymbolType getSymbolType(ICharacterIterator parIterator) throws IOException;
+    SymbolType getSymbolType(ICharacterIterator parIterator) throws IOException, JSONException;
 }

--- a/src/main/java/com/chelseaurquhart/securejson/JSONException.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONException.java
@@ -16,12 +16,10 @@
 
 package com.chelseaurquhart.securejson;
 
-import java.io.IOException;
-
 /**
  * Base class for all SecureJSON exceptions.
  */
-public class JSONException extends IOException {
+public class JSONException extends Exception {
     /**
      * @exclude
      */

--- a/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
@@ -60,15 +60,15 @@ final class JSONReader implements Closeable, AutoCloseable {
         };
     }
 
-    Object read(final CharSequence parJson) throws IOException {
+    Object read(final CharSequence parJson) throws IOException, JSONException {
         return read(new IterableCharSequence(parJson));
     }
 
-    Object read(final InputStream parInputStream) throws IOException {
+    Object read(final InputStream parInputStream) throws IOException, JSONException {
         return read(new IterableInputStream(parInputStream));
     }
 
-    Object read(final ICharacterIterator parIterator) throws IOException {
+    Object read(final ICharacterIterator parIterator) throws IOException, JSONException {
         final Deque<Map.Entry<IReader, Object>> myStack = new ArrayDeque<>();
 
         final Data myData = new Data();
@@ -111,7 +111,7 @@ final class JSONReader implements Closeable, AutoCloseable {
     }
 
     private void readStack(final ICharacterIterator parIterator, final Deque<Map.Entry<IReader, Object>> parStack,
-                           final Data parData) throws IOException {
+                           final Data parData) throws IOException, JSONException {
         while (!parStack.isEmpty()) {
             final Map.Entry<IReader, Object> myHead = parStack.peek();
             if (parData.separatorForObject != myHead) {
@@ -154,7 +154,7 @@ final class JSONReader implements Closeable, AutoCloseable {
         }
     }
 
-    private IReader isStart(final ICharacterIterator parIterator) throws IOException {
+    private IReader isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         for (final IReader myReader : readers) {
             if (myReader.isStart(parIterator)) {
                 return myReader;
@@ -180,7 +180,7 @@ final class JSONReader implements Closeable, AutoCloseable {
         }
     }
 
-    void moveToNextToken(final ICharacterIterator parIterator) throws IOException {
+    void moveToNextToken(final ICharacterIterator parIterator) throws IOException, JSONException {
         while (parIterator.hasNext()) {
             final char myChar = parIterator.peek();
             if (JSONSymbolCollection.WHITESPACES.containsKey(myChar)) {

--- a/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONSymbolCollection.java
@@ -155,7 +155,7 @@ final class JSONSymbolCollection {
             }
         }
 
-        static Token forSymbol(final char parSymbol) throws IOException {
+        static Token forSymbol(final char parSymbol) throws IOException, JSONException {
             final Token myToken = forSymbolOrDefault(parSymbol, null);
 
             if (myToken == null) {

--- a/src/main/java/com/chelseaurquhart/securejson/JSONWriter.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONWriter.java
@@ -45,7 +45,7 @@ class JSONWriter implements Closeable, AutoCloseable {
         settings = parSettings;
     }
 
-    ManagedSecureCharBuffer write(final Object parInput) throws IOException {
+    ManagedSecureCharBuffer write(final Object parInput) throws IOException, InvalidTypeException {
         final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(INITIAL_CAPACITY, settings);
         secureBuffers.add(mySecureBuffer);
 
@@ -53,7 +53,7 @@ class JSONWriter implements Closeable, AutoCloseable {
         return mySecureBuffer;
     }
 
-    void write(final Object parInput, final ICharacterWriter parSecureBuffer) throws IOException {
+    void write(final Object parInput, final ICharacterWriter parSecureBuffer) throws IOException, InvalidTypeException {
         final Object myInput;
         if (objectMutator != null) {
             myInput = objectMutator.accept(parInput);
@@ -92,7 +92,8 @@ class JSONWriter implements Closeable, AutoCloseable {
         }
     }
 
-    private void writeArray(final ICharacterWriter parSecureBuffer, final Object parInput) throws IOException {
+    private void writeArray(final ICharacterWriter parSecureBuffer, final Object parInput) throws IOException,
+            InvalidTypeException {
         parSecureBuffer.append(JSONSymbolCollection.Token.L_BRACE.getShortSymbol());
         final int myLength = Array.getLength(parInput);
         boolean myIsFirst = true;
@@ -106,7 +107,8 @@ class JSONWriter implements Closeable, AutoCloseable {
         parSecureBuffer.append(JSONSymbolCollection.Token.R_BRACE.getShortSymbol());
     }
 
-    private void writeMap(final ICharacterWriter parSecureBuffer, final Map parInput) throws IOException {
+    private void writeMap(final ICharacterWriter parSecureBuffer, final Map parInput) throws IOException,
+            InvalidTypeException {
         parSecureBuffer.append(JSONSymbolCollection.Token.L_CURLY.getShortSymbol());
         boolean myIsFirst = true;
         for (final Object myObject : parInput.entrySet()) {
@@ -130,7 +132,8 @@ class JSONWriter implements Closeable, AutoCloseable {
         parSecureBuffer.append(JSONSymbolCollection.Token.R_CURLY.getShortSymbol());
     }
 
-    private void writeCollection(final ICharacterWriter parSecureBuffer, final Collection parInput) throws IOException {
+    private void writeCollection(final ICharacterWriter parSecureBuffer, final Collection parInput) throws IOException,
+            InvalidTypeException {
         parSecureBuffer.append(JSONSymbolCollection.Token.L_BRACE.getShortSymbol());
         boolean myIsFirst = true;
         for (final Object myElement : parInput) {

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -33,13 +33,13 @@ class ListReader implements IReader<ListReader.Container> {
     }
 
     @Override
-    public boolean isStart(final ICharacterIterator parIterator) throws IOException {
+    public boolean isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
             == JSONSymbolCollection.Token.L_BRACE;
     }
 
     @Override
-    public SymbolType getSymbolType(final ICharacterIterator parIterator) throws IOException {
+    public SymbolType getSymbolType(final ICharacterIterator parIterator) throws IOException, JSONException {
         if (!parIterator.hasNext()) {
             throw new MalformedListException(parIterator);
         }
@@ -58,7 +58,7 @@ class ListReader implements IReader<ListReader.Container> {
     }
 
     @Override
-    public Container read(final ICharacterIterator parIterator) throws IOException {
+    public Container read(final ICharacterIterator parIterator) throws IOException, JSONException {
         parIterator.next();
         jsonReader.moveToNextToken(parIterator);
 
@@ -76,7 +76,7 @@ class ListReader implements IReader<ListReader.Container> {
 
     @Override
     public void addValue(final ICharacterIterator parIterator, final Object parCollection, final Object parValue)
-            throws IOException {
+            throws IOException, JSONException {
         final Container myContainer = objectToContainer(parCollection);
         myContainer.add(parValue);
 

--- a/src/main/java/com/chelseaurquhart/securejson/MapReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/MapReader.java
@@ -35,13 +35,13 @@ class MapReader implements IReader<MapReader.Container> {
     }
 
     @Override
-    public boolean isStart(final ICharacterIterator parIterator) throws IOException {
+    public boolean isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
             == JSONSymbolCollection.Token.L_CURLY;
     }
 
     @Override
-    public SymbolType getSymbolType(final ICharacterIterator parIterator) throws IOException {
+    public SymbolType getSymbolType(final ICharacterIterator parIterator) throws IOException, JSONException {
         if (!parIterator.hasNext()) {
             throw new MalformedMapException(parIterator);
         }
@@ -62,7 +62,7 @@ class MapReader implements IReader<MapReader.Container> {
     }
 
     @Override
-    public Container read(final ICharacterIterator parIterator) throws IOException {
+    public Container read(final ICharacterIterator parIterator) throws IOException, JSONException {
         parIterator.next();
         jsonReader.moveToNextToken(parIterator);
 
@@ -80,7 +80,7 @@ class MapReader implements IReader<MapReader.Container> {
 
     @Override
     public void addValue(final ICharacterIterator parIterator, final Object parCollection, final Object parValue)
-            throws IOException {
+            throws IOException, JSONException {
         final Container myContainer = objectToContainer(parCollection);
         myContainer.put(myContainer.key, parValue);
         jsonReader.moveToNextToken(parIterator);
@@ -113,7 +113,7 @@ class MapReader implements IReader<MapReader.Container> {
         stringReader.close();
     }
 
-    private CharSequence readKey(final ICharacterIterator parIterator) throws IOException {
+    private CharSequence readKey(final ICharacterIterator parIterator) throws IOException, JSONException {
         final CharSequence myKey = stringReader.read(parIterator);
         jsonReader.moveToNextToken(parIterator);
         if (JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)

--- a/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/NumberReader.java
@@ -50,7 +50,7 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
     }
 
     @Override
-    public boolean isStart(final ICharacterIterator parIterator) throws IOException {
+    public boolean isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         return JSONSymbolCollection.NUMBERS.containsKey(parIterator.peek());
     }
 
@@ -60,7 +60,7 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
     }
 
     @Override
-    public Number read(final ICharacterIterator parIterator) throws IOException {
+    public Number read(final ICharacterIterator parIterator) throws IOException, JSONException {
         final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(settings);
         addSecureBuffer(mySecureBuffer);
 
@@ -90,7 +90,7 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
     }
 
     Number charSequenceToNumber(final CharSequence parNumber, final int parOffset)
-            throws IOException {
+            throws IOException, JSONException {
         final Map.Entry<BigDecimal, Boolean> myDecimalAndForceDouble;
         try {
             myDecimalAndForceDouble = charSequenceToBigDecimal(parNumber, parOffset);
@@ -146,7 +146,7 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
     }
 
     Map.Entry<BigDecimal, Boolean> charSequenceToBigDecimal(final CharSequence parSource, final int parOffset)
-            throws IOException {
+            throws IOException, JSONException {
         final char[] myBuffer = new char[parSource.length()];
         try {
             return charSequenceToBigDecimal(parSource, parOffset, myBuffer);
@@ -168,7 +168,7 @@ class NumberReader extends ManagedSecureBufferList implements IReader<Number> {
 
     private Map.Entry<BigDecimal, Boolean> charSequenceToBigDecimal(final CharSequence parSource, final int parOffset,
                                                                     final char[] parBuffer)
-            throws IOException {
+            throws IOException, JSONException {
         boolean myFoundExponent = false;
         boolean myFoundDecimal = false;
         boolean myFoundNonZeroDigit = false;

--- a/src/main/java/com/chelseaurquhart/securejson/ObjectReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ObjectReader.java
@@ -81,11 +81,12 @@ class ObjectReader<T> extends ObjectSerializer {
     }
 
     @SuppressWarnings("unchecked")
-    final T accept(final Object parInput) throws IOException {
+    final T accept(final Object parInput) throws IOException, JSONException {
         return buildInstance(parInput, null);
     }
 
-    private T buildInstance(final Object parInput, final Map<CharSequence, Object> parAbsMap) throws IOException {
+    private T buildInstance(final Object parInput, final Map<CharSequence, Object> parAbsMap) throws IOException,
+            JSONException {
         final T myInstance = construct(clazz);
 
         if (myInstance instanceof IJSONDeserializeAware) {
@@ -107,7 +108,8 @@ class ObjectReader<T> extends ObjectSerializer {
     }
 
     @SuppressWarnings("unchecked")
-    private <U> Class<? extends U> getConcreteClass(final Class<? extends U> parClazz) throws IOException {
+    private <U> Class<? extends U> getConcreteClass(final Class<? extends U> parClazz) throws IOException,
+            JSONException {
         try {
             if (parClazz == Map.class || parClazz == AbstractMap.class) {
                 return (Class<? extends U>) LinkedHashMap.class;
@@ -131,7 +133,7 @@ class ObjectReader<T> extends ObjectSerializer {
     }
 
     private void accept(final Object parInstance, final Map<CharSequence, Object> parRelMap,
-                        final Map<CharSequence, Object> parAbsMap) throws IOException {
+                        final Map<CharSequence, Object> parAbsMap) throws IOException, JSONException {
         for (final Field myField : getFields(clazz)) {
             accept(parInstance, myField, parRelMap, parAbsMap);
         }
@@ -139,7 +141,7 @@ class ObjectReader<T> extends ObjectSerializer {
 
     private void accept(final Object parInstance, final Field parField, final Map<CharSequence, Object> parRelMap,
                         final Map<CharSequence, Object> parAbsMap)
-            throws IOException {
+            throws IOException, JSONException {
         final SerializationSettings mySerializationSettings = getSerializationSettings(parField);
         final Class<?> myType = parField.getType();
         final Object myValue;
@@ -156,7 +158,7 @@ class ObjectReader<T> extends ObjectSerializer {
 
     private <U> boolean recursivelyAccept(final Object parInstance, final Field parField, final Class<U> parType,
                                        final Map<CharSequence, Object> parAbsMap, final Set<Class<?>> parClassStack)
-            throws IOException {
+            throws IOException, JSONException {
         if (!canRecursivelyAccept(parType)) {
             return false;
         }
@@ -252,7 +254,7 @@ class ObjectReader<T> extends ObjectSerializer {
     @SuppressWarnings("unchecked")
     private Object buildValue(final Type parGenericType, final Class<?> parType, final Object parValue,
                               final Map<CharSequence, Object> parAbsMap)
-            throws IOException {
+            throws IOException, JSONException {
         final Class<?> myType;
         if (parType == Object.class && parValue != null) {
             myType = deAnonymize(parValue.getClass());
@@ -309,7 +311,7 @@ class ObjectReader<T> extends ObjectSerializer {
 
     @SuppressWarnings("unchecked")
     private Object buildMapValue(final Type parGenericType, final Class<?> parType, final Map<?, ?> parValue)
-            throws IOException {
+            throws IOException, JSONException {
         final Type myType = TypeResolver.resolveGenericType(parType, parGenericType);
         final Type[] myArgs = getGenericTypes(myType, 2);
         final Class[] myClasses = getGenericArgClasses(myType, 2, parType);
@@ -336,7 +338,7 @@ class ObjectReader<T> extends ObjectSerializer {
 
     @SuppressWarnings("unchecked")
     private Object buildCollectionValue(final Type parGenericType, final Class<?> parType,
-                                        final Collection<?> parValue) throws IOException {
+                                        final Collection<?> parValue) throws IOException, JSONException {
         final Type myType = TypeResolver.resolveGenericType(parType, parGenericType);
         final Type[] myArgs = getGenericTypes(myType, 1);
         final Class[] myClasses = getGenericArgClasses(myType, 1, parType);
@@ -356,7 +358,7 @@ class ObjectReader<T> extends ObjectSerializer {
 
     @SuppressWarnings("unchecked")
     private Object buildArrayValue(final Class<?> parType, final Object parValue)
-            throws IOException {
+            throws IOException, JSONException {
         final Class myClass = parType.getComponentType();
 
         final int myLength = Array.getLength(parValue);

--- a/src/main/java/com/chelseaurquhart/securejson/ObjectSerializer.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ObjectSerializer.java
@@ -18,8 +18,6 @@ package com.chelseaurquhart.securejson;
 
 import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
 
-
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -136,7 +134,7 @@ class ObjectSerializer extends ObjectReflector {
         });
     }
 
-    <U> U construct(final Class<U> parClazz) throws IOException {
+    <U> U construct(final Class<U> parClazz) throws JSONDecodeException {
         final Constructor<? extends U> myConstructor;
         try {
             myConstructor = parClazz.getDeclaredConstructor();

--- a/src/main/java/com/chelseaurquhart/securejson/ObjectWriter.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ObjectWriter.java
@@ -34,13 +34,13 @@ class ObjectWriter extends ObjectSerializer implements IObjectMutator {
         final Map<CharSequence, Object> myRootMap = new LinkedHashMap<>();
         try {
             return accept(parInput, myRootMap, myRootMap);
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             throw new JSONRuntimeException(myException);
         }
     }
 
     private Object accept(final Object parInput, final Map<CharSequence, Object> parRelMap,
-                          final Map<CharSequence, Object> parAbsMap) throws IOException {
+                          final Map<CharSequence, Object> parAbsMap) throws IOException, JSONException {
         final Object myInput = resolve(parInput);
 
         if (isSimpleType(myInput)) {
@@ -84,7 +84,8 @@ class ObjectWriter extends ObjectSerializer implements IObjectMutator {
     }
 
     private Map<CharSequence, Object> addObjectToMap(final Object parInput, final Map<CharSequence, Object> parRelMap,
-                                                     final Map<CharSequence, Object> parAbsMap) throws IOException {
+                                                     final Map<CharSequence, Object> parAbsMap) throws IOException,
+            JSONException {
         for (final Field myField : getFields(parInput.getClass())) {
             final SerializationSettings mySerializationSettings = getSerializationSettings(myField);
             final Object myFieldValue = accept(getValue(myField, parInput), parRelMap, parAbsMap);
@@ -102,7 +103,7 @@ class ObjectWriter extends ObjectSerializer implements IObjectMutator {
 
     private void addToMap(final Object parFieldValue, final Map<CharSequence, Object> parTargetMap,
                           final Map<CharSequence, Object> parAbsMap, final CharSequence[] parTarget)
-            throws IOException {
+            throws IOException, JSONException {
 
         Map<CharSequence, Object> myTargetMap = parTargetMap;
 

--- a/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
+++ b/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
@@ -191,7 +191,7 @@ public final class SecureJSON {
 
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
-        } catch (final JSONRuntimeException | IOException | ClassCastException myException) {
+        } catch (final JSONException | JSONRuntimeException | IOException | ClassCastException myException) {
             throw JSONDecodeException.fromException(myException);
         }
     }
@@ -275,7 +275,7 @@ public final class SecureJSON {
 
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(new ByteArrayInputStream(parInput)));
-        } catch (final JSONRuntimeException | IOException | ClassCastException myException) {
+        } catch (final JSONException | JSONRuntimeException | IOException | ClassCastException myException) {
             throw JSONDecodeException.fromException(myException);
         }
     }
@@ -364,7 +364,7 @@ public final class SecureJSON {
 
         try (final JSONReader myJsonReader = new JSONReader.Builder(settings).build()) {
             parConsumer.accept((T) myJsonReader.read(parInput));
-        } catch (final JSONRuntimeException | IOException | ClassCastException myException) {
+        } catch (final JSONException | JSONRuntimeException | IOException | ClassCastException myException) {
             throw JSONDecodeException.fromException(myException);
         }
     }
@@ -429,7 +429,7 @@ public final class SecureJSON {
                 try {
                     parConsumer.accept(new ObjectReader<>(parClass, settings)
                         .accept(parOutput));
-                } catch (final IOException myException) {
+                } catch (final IOException | JSONException myException) {
                     throw new JSONRuntimeException(myException);
                 }
             }

--- a/src/main/java/com/chelseaurquhart/securejson/StringReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/StringReader.java
@@ -34,7 +34,7 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
     }
 
     @Override
-    public boolean isStart(final ICharacterIterator parIterator) throws IOException {
+    public boolean isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         return JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(), null)
             == JSONSymbolCollection.Token.QUOTE;
     }
@@ -45,8 +45,7 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
     }
 
     @Override
-    public CharSequence read(final ICharacterIterator parInput)
-            throws IOException {
+    public CharSequence read(final ICharacterIterator parInput) throws IOException, JSONException {
         if (JSONSymbolCollection.Token.forSymbolOrDefault(parInput.peek(), null) != JSONSymbolCollection.Token.QUOTE) {
             throw new MalformedStringException(parInput);
         }
@@ -113,7 +112,7 @@ class StringReader extends ManagedSecureBufferList implements IReader<CharSequen
         return false;
     }
 
-    private char readUnicode(final ICharacterIterator parInput) throws IOException {
+    private char readUnicode(final ICharacterIterator parInput) throws IOException, MalformedUnicodeValueException {
         int myValue = 0;
         for (int myIndex = 0; myIndex < JSONSymbolCollection.UNICODE_DIGITS; myIndex++) {
             final char myChar = Character.toLowerCase(parInput.next());

--- a/src/main/java/com/chelseaurquhart/securejson/WordReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/WordReader.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  */
 class WordReader implements IReader<Object> {
     @Override
-    public boolean isStart(final ICharacterIterator parIterator) throws IOException {
+    public boolean isStart(final ICharacterIterator parIterator) throws IOException, JSONException {
         return JSONSymbolCollection.WORD_TOKENS.get(parIterator.peek()) != null;
     }
 
@@ -35,8 +35,7 @@ class WordReader implements IReader<Object> {
     }
 
     @Override
-    public Object read(final ICharacterIterator parIterator)
-            throws IOException {
+    public Object read(final ICharacterIterator parIterator) throws IOException, JSONException {
 
         final JSONSymbolCollection.Token myWordToken = JSONSymbolCollection.WORD_TOKENS.get(parIterator.peek());
         if (myWordToken != null) {
@@ -59,7 +58,7 @@ class WordReader implements IReader<Object> {
     }
 
     private void readAndValidateWord(final ICharacterIterator parIterator, final JSONSymbolCollection.Token parToken)
-            throws IOException {
+            throws IOException, JSONException {
         final CharSequence myWord = parToken.toString().toLowerCase();
         final int myCheckingLength = myWord.length();
 

--- a/src/test/java/com/chelseaurquhart/securejson/HugeDecimalTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/HugeDecimalTest.java
@@ -85,7 +85,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.bigDecimalValue(), parParameters.expectedBigDecimal);
-                } catch (final IOException myException) {
+                } catch (final IOException | JSONException myException) {
                     throw new JSONException.JSONRuntimeException(myException);
                 } catch (final NumberFormatException | ArithmeticException myException) {
                     Assert.assertNull(parParameters.expectedBigDecimal);
@@ -101,7 +101,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.bigIntegerValue(), parParameters.expectedBigInteger);
-                } catch (final IOException myException) {
+                } catch (final IOException | JSONException myException) {
                     throw new JSONException.JSONRuntimeException(myException);
                 } catch (final NumberFormatException | ArithmeticException myException) {
                     Assert.assertNull(parParameters.expectedBigInteger);

--- a/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
@@ -21,6 +21,7 @@ import com.chelseaurquhart.securejson.JSONDecodeException.ExtraCharactersExcepti
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedJSONException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedListException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedStringException;
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
 
 import com.chelseaurquhart.securejson.util.StringUtil;
 import org.testng.Assert;
@@ -417,7 +418,7 @@ public final class JSONReaderTest {
             Assert.assertNull(parExpectedException, "Expected exception was not thrown");
             Assert.assertEquals(StringUtil.deepCharSequenceToString(myActual),
                 StringUtil.deepCharSequenceToString(parExpected));
-        } catch (final IOException | JSONException.JSONRuntimeException myException) {
+        } catch (final IOException | JSONException | JSONRuntimeException myException) {
             Assert.assertNotNull(parExpectedException);
             Assert.assertEquals(Util.unwrapException(myException).getMessage(),
                 parExpectedException.getMessage());

--- a/src/test/java/com/chelseaurquhart/securejson/JSONWriterTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONWriterTest.java
@@ -17,6 +17,8 @@
 package com.chelseaurquhart.securejson;
 
 import com.chelseaurquhart.securejson.util.StringUtil;
+import com.chelseaurquhart.securejson.JSONEncodeException.InvalidTypeException;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -109,7 +111,7 @@ public final class JSONWriterTest {
     }
 
     @Test(dataProvider = DATA_PROVIDER_NAME)
-    public void testWrite(final Parameters parParameters) throws IOException {
+    public void testWrite(final Parameters parParameters) throws IOException, InvalidTypeException {
         try (final JSONWriter myWriter = new JSONWriter(Settings.DEFAULTS)) {
             Assert.assertEquals(StringUtil.deepCharSequenceToString(myWriter.write(parParameters.inputObject)),
                 StringUtil.deepCharSequenceToString(parParameters.expected));

--- a/src/test/java/com/chelseaurquhart/securejson/NumberReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/NumberReaderTest.java
@@ -30,7 +30,7 @@ public final class NumberReaderTest {
             Assert.assertNull(parParameters.expectedException);
             Assert.assertSame(myNumber.getClass(), parParameters.expectedNumberClass);
             Assert.assertEquals(myNumber, parParameters.expected);
-        } catch (final IOException | JSONException.JSONRuntimeException myException) {
+        } catch (final IOException | JSONException myException) {
             Assert.assertNotNull(parParameters.expectedException, myException.getMessage());
             Assert.assertEquals(myException.getMessage(), parParameters.expectedException.getMessage());
             Assert.assertEquals(myException.getClass(), parParameters.expectedException.getClass());
@@ -38,17 +38,17 @@ public final class NumberReaderTest {
     }
 
     @Test
-    public void testDefaults() throws IOException {
+    public void testDefaults() throws IOException, JSONException {
         Assert.assertEquals((short) 220, charSequenceToNumber("22e1", NumberReader.DEFAULT_MATH_CONTEXT));
     }
 
     private Number charSequenceToNumber(final CharSequence parNumber, final MathContext parMathContext)
-            throws IOException {
+            throws IOException, JSONException {
         return new NumberReader(parMathContext, Settings.DEFAULTS).charSequenceToNumber(parNumber, 0);
     }
 
     @Test(expectedExceptions = NotImplementedException.class)
-    public void testAddValue() throws IOException {
+    public void testAddValue() throws IOException, JSONException {
         final IReader myNumberReader = new NumberReader(Settings.DEFAULTS);
         myNumberReader.addValue(null, null, null);
     }

--- a/src/test/java/com/chelseaurquhart/securejson/ObjectReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/ObjectReaderTest.java
@@ -17,6 +17,8 @@
 package com.chelseaurquhart.securejson;
 
 import com.chelseaurquhart.securejson.util.StringUtil;
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
@@ -60,7 +62,7 @@ public final class ObjectReaderTest {
     }
 
     @Test
-    public void testSimpleDeserialization() throws IOException {
+    public void testSimpleDeserialization() throws IOException, JSONException {
         final SimpleDeserializationClass mySimpleDeserializationClass = new ObjectReader<>(
             SimpleDeserializationClass.class, UNSTRICT_SETTINGS).accept(new HashMap<CharSequence, Object>() {{
                     put("integerVal", 1);
@@ -95,13 +97,13 @@ public final class ObjectReaderTest {
             SJSecurityManager.SECURITY_VIOLATIONS.add(new ReflectPermission("suppressAccessChecks"));
             testSimpleDeserialization();
             Assert.fail("Expected exception not thrown");
-        } catch (final JSONException.JSONRuntimeException myException) {
+        } catch (final JSONException | JSONRuntimeException myException) {
             Assert.assertEquals(myException.getCause().getClass(), SecurityException.class);
         }
     }
 
     @Test
-    public void testSimpleNesting() throws IOException {
+    public void testSimpleNesting() throws IOException, JSONException {
         final SimpleNestingClass mySimpleNestingClass = new ObjectReader<>(
             SimpleNestingClass.class, UNSTRICT_SETTINGS).accept(new HashMap<CharSequence, Object>() {{
                     put("inner1", new HashMap<CharSequence, Object>() {{
@@ -142,7 +144,7 @@ public final class ObjectReaderTest {
     }
 
     @Test
-    public void testSubNesting() throws IOException {
+    public void testSubNesting() throws IOException, JSONException {
         final SubNestingClass mySubNestingClass = new ObjectReader<>(
             SubNestingClass.class, UNSTRICT_SETTINGS).accept(new HashMap<CharSequence, Object>() {{
                     put("inner1", new HashMap<CharSequence, Object>() {{
@@ -174,7 +176,7 @@ public final class ObjectReaderTest {
     }
 
     @Test
-    public void testRecursiveNesting() throws IOException {
+    public void testRecursiveNesting() throws IOException, JSONException {
         final SubNestingClass mySubNestingClass = new ObjectReader<>(
                 SubNestingClass.class, UNSTRICT_SETTINGS)
                     .accept(new HashMap<CharSequence, Object>() {{
@@ -238,7 +240,7 @@ public final class ObjectReaderTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testComplexType() throws IOException {
+    public void testComplexType() throws IOException, JSONException {
         final ComplexTypeClass myComplexTypeClass = new ObjectReader<>(
                 ComplexTypeClass.class, Settings.DEFAULTS).accept(new HashMap<CharSequence, Object>() {{
                         final List<Map<CharSequence, Map<String, Integer>>> myList1 = new ArrayList<>();
@@ -275,7 +277,7 @@ public final class ObjectReaderTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testAbsoluteNesting() throws IOException {
+    public void testAbsoluteNesting() throws IOException, JSONException {
         final NestingAbsClass myNestingAbsClass = new ObjectReader<>(
             NestingAbsClass.class, Settings.DEFAULTS).accept(new HashMap<CharSequence, Object>() {{
                     put("1", 11);
@@ -301,7 +303,7 @@ public final class ObjectReaderTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void testConcreteConstruction() throws IOException {
+    public void testConcreteConstruction() throws IOException, JSONException {
         final NestingAbsClass.ConcreteTest myConcreteTest = new ObjectReader<>(
                 NestingAbsClass.ConcreteTest.class, Settings.DEFAULTS).accept(new HashMap<CharSequence, Object>() {{
                         put("genericMap", new TreeMap<CharSequence, Object>() {{
@@ -370,7 +372,7 @@ public final class ObjectReaderTest {
 
     @SuppressWarnings("unchecked")
     @Test(expectedExceptions = JSONException.JSONRuntimeException.class)
-    public void testUnknownType() throws IOException {
+    public void testUnknownType() throws IOException, JSONException {
         new ObjectReader<>(
             NestingAbsClass.InvalidClassTest.class, Settings.DEFAULTS).accept(new HashMap<CharSequence, Object>() {{
                     put("calendar", new ArrayList<Object>() {{

--- a/src/test/java/com/chelseaurquhart/securejson/SecureJSONTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/SecureJSONTest.java
@@ -23,7 +23,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
@@ -42,7 +41,7 @@ public final class SecureJSONTest {
                 }
             });
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
-        } catch (final IOException | JSONRuntimeException myException) {
+        } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
         }
     }
@@ -61,7 +60,7 @@ public final class SecureJSONTest {
                 }
             });
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
-        } catch (final IOException | JSONRuntimeException myException) {
+        } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
         }
     }
@@ -84,7 +83,7 @@ public final class SecureJSONTest {
                 }
             });
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
-        } catch (final IOException | JSONRuntimeException myException) {
+        } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
         }
     }

--- a/src/test/java/com/chelseaurquhart/securejson/StringReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/StringReaderTest.java
@@ -40,7 +40,7 @@ public final class StringReaderTest {
             CharBuffer.wrap(myResult).get(myActualChars);
             CharBuffer.wrap(parParameters.expected).get(myExpectedChars);
             Assert.assertEquals(new String(myActualChars), new String(myExpectedChars));
-        } catch (final IOException | JSONRuntimeException myException) {
+        } catch (final IOException | JSONException | JSONRuntimeException myException) {
             Assert.assertNotNull(parParameters.expectedException, myException.getMessage());
             Assert.assertEquals(myException.getMessage(), parParameters.expectedException.getMessage());
             Assert.assertEquals(myException.getClass(), parParameters.expectedException.getClass());
@@ -48,7 +48,7 @@ public final class StringReaderTest {
     }
 
     @Test(expectedExceptions = NotImplementedException.class)
-    public void testAddValue() throws IOException {
+    public void testAddValue() throws IOException, JSONException {
         final IReader myStringReader = new StringReader(Settings.DEFAULTS);
         myStringReader.addValue(null, null, null);
     }

--- a/src/test/java/com/chelseaurquhart/securejson/WordReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/WordReaderTest.java
@@ -101,7 +101,7 @@ public final class WordReaderTest {
             Assert.assertEquals(myWordReader.read(new IterableCharSequence(parParameters.input)),
                 parParameters.expected);
             Assert.assertNull(parParameters.expectedException);
-        } catch (final IOException myException) {
+        } catch (final IOException | JSONException myException) {
             Assert.assertNotNull(parParameters.expectedException, myException.getMessage());
             Assert.assertEquals(myException.getMessage(), parParameters.expectedException.getMessage());
             Assert.assertEquals(myException.getClass(), parParameters.expectedException.getClass());
@@ -109,7 +109,7 @@ public final class WordReaderTest {
     }
 
     @Test(expectedExceptions = NotImplementedException.class)
-    public void testAddValue() throws IOException {
+    public void testAddValue() throws IOException, JSONException {
         final IReader myWordReader = new WordReader();
         myWordReader.addValue(null, null, null);
     }


### PR DESCRIPTION
resolve json exception too many parents errors in sonarqube by removing the IOException parent from JSONException.