### PR TITLE
Increase unit test coverage, fix minor issues, and proper java 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ sourceSets {
         java {
             srcDirs 'src/shared/java'
         }
+        compileClasspath += sourceSets.main.output
     }
 
     cli {

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.85
+                minimum = 0.90
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -77,26 +77,38 @@ sourceSets {
     }
 }
 
-if (JavaVersion.current().java9Compatible) {
-    compileJava {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
-        options.compilerArgs.addAll(['--release', '7'])
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
+if (JavaVersion.current().java8Compatible) {
+    def stdOut = new ByteArrayOutputStream()
+    try {
+        exec {
+            commandLine '/usr/libexec/java_home', '-v', '1.7'
+            standardOutput = stdOut
+        }
+
+        def bootstrapPath = "${stdOut.toString().trim()}/jre/lib/rt.jar"
+        project.tasks.withType(AbstractCompile, { ac ->
+            ac.options.bootstrapClasspath = files(bootstrapPath)
+        })
+        println "Using bootstrap path: ${bootstrapPath}"
+    } catch (final Exception e) {
+        println "Failed to get Java 7 home. Bootstrap path will not be set: ${e.getMessage()}"
     }
-} else {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
 }
 
 if (JavaVersion.current().java9Compatible) {
+    compileJava {
+        options.compilerArgs.addAll(['--release', '7'])
+    }
+
     compileJava9Java {
         sourceCompatibility = 9
         targetCompatibility = 9
         options.compilerArgs.addAll(['--release', '9'])
     }
-}
 
-if (JavaVersion.current().java9Compatible) {
     jar {
         into('META-INF/versions/9') {
             from sourceSets.java9.output

--- a/config/checkstyle.suppressions.xml
+++ b/config/checkstyle.suppressions.xml
@@ -5,7 +5,7 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-    <suppress checks="MethodLength|MagicNumber|ParameterNumber|JavadocType" files="test/java/.*(Test|NumberProvider|StringProvider)\.java$"/>
+    <suppress checks="MethodLength|MagicNumber|ParameterNumber|JavadocType|FinalClass" files="test/java/.*(Test|NumberProvider|StringProvider)\.java$"/>
     <suppress checks="MethodLength|MagicNumber|ParameterNumber|JavadocType" files="objectSerializationTest/java/.*Test\.java$"/>
     <suppress checks="AvoidInlineConditionals|VisibilityModifier" files="test/java/.*(NumberProvider|StringProvider)\.java$"/>
     <suppress checks="IllegalCatch" files="ObjectSerializer\.java$"/>

--- a/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
+++ b/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
@@ -76,7 +76,7 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
         // the only special characters we need to handle.
 
         if (!hasNext()) {
-            throw new JSONException(Messages.get(Messages.Key.ERROR_MALFORMED_JSON));
+            return Encoding.UTF8;
         }
         final char myNextChar = peek();
         switch (myNextChar) {

--- a/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
+++ b/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
@@ -67,6 +67,10 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
         return charQueue.peek();
     }
 
+    Encoding getEncoding() {
+        return encoding;
+    }
+
     private Encoding findEncoding() throws IOException, JSONException {
         // We can accept either encoding. UTF-8 characters, other than the BOM, are not allowed in JSON, so these are
         // the only special characters we need to handle.
@@ -244,7 +248,10 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
         switch (encoding) {
             case UTF16BE:
                 // support UTF8 with UTF16 BOM. >.<
-                readNullChars(UTF16_BYTES - 1);
+                if (readNullChars(UTF16_BYTES - 1) == 0) {
+                    // We read a BOM, but we do not have nulls in the data. This means it is actually UTF8.
+                    encoding = Encoding.UTF8;
+                }
                 if (charQueue.isEmpty()) {
                     myChar = readNextChar();
                 } else {
@@ -308,7 +315,7 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
      */
     protected abstract Character readNextChar() throws IOException;
 
-    private enum Encoding {
+    enum Encoding {
         UTF8,
         UTF16BE,
         UTF16LE,

--- a/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
+++ b/src/main/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIterator.java
@@ -82,12 +82,14 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
         switch (myNextChar) {
             case UTF8_BOM_CHAR0:
                 next();
-                if (!hasNext() || next() != UTF8_BOM_CHAR1) {
+                if (!hasNext() || peek() != UTF8_BOM_CHAR1) {
                     throw new MalformedJSONException(this);
                 }
-                if (!hasNext() || next() != UTF8_BOM_CHAR2) {
+                next();
+                if (!hasNext() || peek() != UTF8_BOM_CHAR2) {
                     throw new MalformedJSONException(this);
                 }
+                next();
                 return Encoding.UTF8;
             case UTF_BIG_ENDIAN:
                 next();
@@ -104,9 +106,10 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
             case UTF16_BOM_CHAR0:
                 next();
                 // big-endian
-                if (!hasNext() || next() != UTF16_BOM_CHAR1) {
+                if (!hasNext() || peek() != UTF16_BOM_CHAR1) {
                     throw new MalformedJSONException(this);
                 }
+                next();
                 return Encoding.UTF16BE;
             case UTF16_BOM_CHAR1:
                 return findUtf16Or32LittleEndianEncoding(UTF16_BOM_CHAR0);
@@ -118,9 +121,10 @@ abstract class EncodingAwareCharacterIterator implements ICharacterIterator {
     private Encoding findUtf16Or32LittleEndianEncoding(final char parUtf16BomChar0) throws IOException, JSONException {
         next();
         // little-endian
-        if (!hasNext() || next() != parUtf16BomChar0) {
+        if (!hasNext() || peek() != parUtf16BomChar0) {
             throw new MalformedJSONException(this);
         }
+        next();
         if (findPartialUtf32Encoding() == Encoding.UTF32) {
             return Encoding.UTF32LE;
         }

--- a/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
+++ b/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  *   a) not be stored in numeric types or
  *   b) should be retrieved from HugeDecimal.charSequenceValue()
  */
-public final class HugeDecimal extends Number implements CharSequence, IJSONSerializeAware {
+public final class HugeDecimal extends Number implements CharSequence {
     private static final long serialVersionUID = 1L;
 
     private transient CharSequence chars;
@@ -257,15 +257,6 @@ public final class HugeDecimal extends Number implements CharSequence, IJSONSeri
             chars = number.toString();
         }
         return chars.subSequence(parStart, parEnd);
-    }
-
-    @Override
-    public Object toJSONable() {
-        if (number == null) {
-            return chars;
-        }
-
-        return number;
     }
 
     private void writeObject(final ObjectOutputStream parObjectOutputStream) throws IOException {

--- a/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
+++ b/src/main/java/com/chelseaurquhart/securejson/HugeDecimal.java
@@ -261,6 +261,10 @@ public final class HugeDecimal extends Number implements CharSequence, IJSONSeri
 
     @Override
     public Object toJSONable() {
+        if (number == null) {
+            return chars;
+        }
+
         return number;
     }
 

--- a/src/main/java/com/chelseaurquhart/securejson/JSONException.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONException.java
@@ -45,9 +45,5 @@ public class JSONException extends Exception {
         JSONRuntimeException(final Exception parInput) {
             super(parInput);
         }
-
-        JSONRuntimeException(final String parMessage) {
-            super(parMessage);
-        }
     }
 }

--- a/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONReader.java
@@ -89,9 +89,6 @@ final class JSONReader implements Closeable, AutoCloseable {
                 myReaderData.hasResult = false;
             }
             moveToNextToken(parIterator);
-            if (myReaderData.hasResult) {
-                myReaderData.separatorForObject = null;
-            }
 
             myReaderData.isFinished = true;
             readStack(parIterator, myStack, myReaderData);
@@ -130,9 +127,6 @@ final class JSONReader implements Closeable, AutoCloseable {
         final IReader<?> myReader = myHead.first;
         final Object myValue = myHead.second;
 
-        if (parReaderData.separatorForObject != myReader) {
-            parReaderData.separatorForObject = null;
-        }
         final IReader.SymbolType mySymbolType = myReader.getSymbolType(parIterator);
         if (parReaderData.hasResult) {
             myReader.addValue(parIterator, myValue, parReaderData.result);
@@ -157,15 +151,11 @@ final class JSONReader implements Closeable, AutoCloseable {
         }
         // keep reading
         parReaderData.isFinished = false;
-        parReaderData.separatorForObject = parReader;
     }
 
     private void readStackEnd(final ICharacterIterator parIterator, final IReader<?> parReader, final Object parValue,
                               final ReaderData parReaderData, final PairStack<IReader<?>, Object> parStack)
             throws IOException, JSONException {
-        if (parReaderData.separatorForObject == parReader) {
-            throw new InvalidTokenException(parIterator);
-        }
         parStack.pop();
         parIterator.next();
         moveToNextToken(parIterator);
@@ -254,7 +244,6 @@ final class JSONReader implements Closeable, AutoCloseable {
      * Data for use by the JSON Reader.
      */
     private static class ReaderData {
-        private transient IReader<?> separatorForObject;
         private transient boolean isFinished;
         private transient Object result;
         private transient boolean hasResult;

--- a/src/main/java/com/chelseaurquhart/securejson/JSONWriter.java
+++ b/src/main/java/com/chelseaurquhart/securejson/JSONWriter.java
@@ -56,8 +56,8 @@ class JSONWriter implements Closeable, AutoCloseable {
     void write(final Object parInput, final ICharacterWriter parSecureBuffer) throws IOException, InvalidTypeException {
         final Object myInput = mutateInput(parInput);
 
-        if (myInput instanceof IJSONAware) {
-            write(((IJSONAware) myInput).toJSONable(), parSecureBuffer);
+        if (myInput instanceof IJSONSerializeAware) {
+            write(((IJSONSerializeAware) myInput).toJSONable(), parSecureBuffer);
             return;
         }
 

--- a/src/main/java/com/chelseaurquhart/securejson/ListReader.java
+++ b/src/main/java/com/chelseaurquhart/securejson/ListReader.java
@@ -40,10 +40,6 @@ class ListReader implements IReader<ListReader.Container> {
 
     @Override
     public SymbolType getSymbolType(final ICharacterIterator parIterator) throws IOException, JSONException {
-        if (!parIterator.hasNext()) {
-            throw new MalformedListException(parIterator);
-        }
-
         final JSONSymbolCollection.Token myToken = JSONSymbolCollection.Token.forSymbolOrDefault(parIterator.peek(),
             JSONSymbolCollection.Token.UNKNOWN);
 

--- a/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
+++ b/src/main/java/com/chelseaurquhart/securejson/SecureJSON.java
@@ -322,7 +322,6 @@ public final class SecureJSON {
             throws JSONDecodeException {
         Objects.requireNonNull(parInput);
         Objects.requireNonNull(parConsumer);
-        Objects.requireNonNull(parClass);
 
         fromJSON(parInput, getConsumer(parConsumer, parClass));
     }
@@ -411,7 +410,6 @@ public final class SecureJSON {
             throws JSONDecodeException {
         Objects.requireNonNull(parInput);
         Objects.requireNonNull(parConsumer);
-        Objects.requireNonNull(parClass);
 
         fromJSON(parInput, getConsumer(parConsumer, parClass));
     }

--- a/src/shared/java/com/chelseaurquhart/securejson/util/StringUtil.java
+++ b/src/shared/java/com/chelseaurquhart/securejson/util/StringUtil.java
@@ -16,6 +16,8 @@
 
 package com.chelseaurquhart.securejson.util;
 
+import com.chelseaurquhart.securejson.IJSONSerializeAware;
+
 import java.nio.CharBuffer;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -63,6 +65,8 @@ public final class StringUtil {
             for (int myIndex = 0; myIndex < myInputArray.length; myIndex++) {
                 myInputArray[myIndex] = deepCharSequenceToString(myInputArray[myIndex]);
             }
+        } else if (parInput instanceof IJSONSerializeAware) {
+            return deepCharSequenceToString(((IJSONSerializeAware) parInput).toJSONable());
         }
 
         return parInput;

--- a/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/CharQueueTest.java
@@ -37,8 +37,21 @@ public final class CharQueueTest {
     }
 
     @Test(expectedExceptions = JSONRuntimeException.class)
+    public void testAddBufferOverflowSingleCharCapacity() {
+        final CharQueue myQueue = new CharQueue(1);
+        myQueue.add('a');
+        myQueue.add('b');
+    }
+
+    @Test(expectedExceptions = JSONRuntimeException.class)
     public void testPopBufferUnderflow() {
         final CharQueue myQueue = new CharQueue(4);
+        myQueue.pop();
+    }
+
+    @Test(expectedExceptions = JSONRuntimeException.class)
+    public void testPopBufferUnderflowSingleCharCapacity() {
+        final CharQueue myQueue = new CharQueue(1);
         myQueue.pop();
     }
 

--- a/src/test/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIteratorTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/EncodingAwareCharacterIteratorTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2018 Chelsea Urquhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chelseaurquhart.securejson;
+
+import com.chelseaurquhart.securejson.EncodingAwareCharacterIterator.Encoding;
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
+import com.chelseaurquhart.securejson.JSONDecodeException.InvalidTokenException;
+import com.chelseaurquhart.securejson.JSONDecodeException.MalformedJSONException;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+@SuppressWarnings("PMD.CommentRequired")
+public final class EncodingAwareCharacterIteratorTest {
+    static final String DATA_PROVIDER_NAME = "EncodingAwareCharacterIteratorTest";
+
+    @DataProvider(name = DATA_PROVIDER_NAME, parallel = true)
+    static Object[] dataProvider() throws IOException {
+        return new Object[]{
+            new Parameters(
+                "empty string",
+                "",
+                new char[0],
+                null,
+                Encoding.UTF8
+            ),
+            new Parameters(
+                "single character",
+                "a",
+                new char[]{'a'},
+                null,
+                Encoding.UTF8
+            ),
+            new Parameters(
+                "single character but iterated to end",
+                new EACIIterator("a", new IConsumer<EACIIterator>() {
+                    @Override
+                    public void accept(final EACIIterator parInput) {
+                        parInput.next();
+                    }
+                }),
+                new char[0],
+                null,
+                Encoding.UTF8
+            ),
+            new Parameters(
+                "UTF8 BOM",
+                new String(new char[]{0xef, 0xbb, 0xbf, 'a', 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF8
+            ),
+            new Parameters(
+                "UTF8 malformed BOM - missing last char",
+                new String(new char[]{0xef,  0xbb, 'a', 'b'}),
+                null,
+                new MalformedJSONException(new PresetIterableCharSequence(2)),
+                null
+            ),
+            new Parameters(
+                "UTF8 malformed BOM - missing second char",
+                new String(new char[]{0xef, 'a', 'b'}),
+                null,
+                new MalformedJSONException(new PresetIterableCharSequence(1)),
+                null
+            ),
+            new Parameters(
+                "UTF16 BOM big-endian",
+                new String(new char[]{0xfe, 0xff, 0, 'a', 0, 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF16BE
+            ),
+            new Parameters(
+                "UTF16 NO BOM big-endian",
+                new String(new char[]{0, 'a', 0, 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF16BE
+            ),
+            new Parameters(
+                "UTF8 with BOM",
+                new String(new char[]{0, 'a', 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF8
+            ),
+            new Parameters(
+                "UTF16 BOM little-endian",
+                new String(new char[]{0xff, 0xfe, 'a', 0, 'b', 0}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF16LE
+            ),
+            new Parameters(
+                "UTF16 BOM little-endian, missing second marker byte",
+                new String(new char[]{0xff, 'a', 0, 'b', 0}),
+                new char[]{'a', 'b'},
+                new MalformedJSONException(new PresetIterableCharSequence(1)),
+                null
+            ),
+            new Parameters(
+                "UTF16 NO BOM little-endian",
+                new String(new char[]{'a', 0, 'b', 0}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF16LE
+            ),
+            new Parameters(
+                "UTF32 BOM big-endian",
+                new String(new char[]{0, 0, (char) 0xfe, (char) 0xff, 0, 0, 0, 'a', 0, 0, 0, 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF32BE
+            ),
+            new Parameters(
+                "UTF32 BOM big-endian, missing second marker byte",
+                new String(new char[]{0, 0, (char) 0xfe, 0, 0, 0, 'a', 0, 0, 0, 'b'}),
+                new char[]{'a', 'b'},
+                new MalformedJSONException(new PresetIterableCharSequence(3)),
+                null
+            ),
+            new Parameters(
+                "UTF32 NO BOM big-endian",
+                new String(new char[]{0, 0, 0, 'a', 0, 0, 0, 'b'}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF32BE
+            ),
+            new Parameters(
+                "UTF32 NO BOM big-endian, malformed",
+                new String(new char[]{0, 0, 0, 'a', 0, 0, 'b'}),
+                new char[]{'a'},
+                new InvalidTokenException(new PresetIterableCharSequence(6)),
+                Encoding.UTF32BE
+            ),
+            new Parameters(
+                "UTF32 BOM little-endian",
+                new String(new char[]{0xff, 0xfe, 0, 0, 'a', 0, 0, 0, 'b', 0, 0, 0}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF32LE
+            ),
+            new Parameters(
+                "UTF32 NO BOM little-endian",
+                new String(new char[]{'a', 0, 0, 0, 'b', 0, 0, 0}),
+                new char[]{'a', 'b'},
+                null,
+                Encoding.UTF32LE
+            ),
+        };
+    }
+
+    @Test(dataProvider = DATA_PROVIDER_NAME)
+    public void testIterate(final Parameters parParameters) {
+        try {
+            if (parParameters.expected == null || parParameters.expected.length == 0) {
+                Assert.assertFalse(parParameters.input.hasNext());
+            } else {
+                for (int myIndex = 0; myIndex < parParameters.expected.length; myIndex++) {
+                    final Character myChar = parParameters.expected[myIndex];
+                    Assert.assertTrue(parParameters.input.hasNext());
+                    Assert.assertEquals(parParameters.input.peek(), myChar);
+                    Assert.assertEquals(parParameters.input.next(), myChar);
+                }
+                Assert.assertFalse(parParameters.input.hasNext());
+            }
+            Assert.assertNull(parParameters.expectedException);
+        } catch (final JSONException | JSONRuntimeException | IOException myException) {
+            Assert.assertNotNull(parParameters.expectedException, "exception \"" + myException.getMessage() + "\"");
+            Assert.assertEquals(Util.unwrapException(myException).getMessage(),
+                parParameters.expectedException.getMessage());
+        } finally {
+            // we must check encoding after because we do not know the encoding until we start reading.
+            // if encoding is malformed we could know the encoding but still get an error. Due to this, check the
+            // encoding, even on error.
+            Assert.assertEquals(parParameters.input.getEncoding(), parParameters.expectedEncoding);
+        }
+    }
+
+    static class EACIIterator extends EncodingAwareCharacterIterator {
+        private final CharSequence input;
+        private int index;
+
+        EACIIterator(final CharSequence parInput, final IConsumer<EACIIterator> parInitializer) {
+            this(parInput);
+            parInitializer.accept(this);
+        }
+
+        EACIIterator(final CharSequence parInput) {
+            final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(parInput.length(),
+                    Settings.DEFAULTS);
+            mySecureBuffer.append(parInput);
+            input = mySecureBuffer;
+        }
+
+        @Override
+        protected Character readNextChar() {
+            if (index == input.length()) {
+                return null;
+            }
+
+            return input.charAt(index++);
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    static class Parameters {
+        private String testName;
+        private EACIIterator input;
+        private char[] expected;
+        private Exception expectedException;
+        private EncodingAwareCharacterIterator.Encoding expectedEncoding;
+
+        Parameters(final String parTestName, final CharSequence parInput, final char[] parExpected,
+                   final Exception parExpectedException, final Encoding parExpectedEncoding) {
+            this(parTestName, new EACIIterator(parInput), parExpected, parExpectedException, parExpectedEncoding);
+        }
+
+        Parameters(final String parTestName, final EACIIterator parInput, final char[] parExpected,
+                   final Exception parExpectedException, final Encoding parExpectedEncoding) {
+            testName = parTestName;
+            input = parInput;
+            expected = parExpected;
+            expectedException = parExpectedException;
+            expectedEncoding = parExpectedEncoding;
+        }
+
+        @Override
+        public String toString() {
+            return testName;
+        }
+    }
+
+}

--- a/src/test/java/com/chelseaurquhart/securejson/HugeDecimalTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/HugeDecimalTest.java
@@ -17,6 +17,8 @@
 package com.chelseaurquhart.securejson;
 
 import com.chelseaurquhart.securejson.util.StringUtil;
+import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -72,10 +74,40 @@ public final class HugeDecimalTest {
                 .expectedShort((short) -1)
                 .expectedCharSequence("-1"),
             new Parameters(
+                "big integer value that can be represented in all types",
+                BigInteger.valueOf(-1)
+            )
+                .expectedBigDecimal(BigDecimal.ONE.negate())
+                .expectedBigInteger(BigInteger.ONE.negate())
+                .expectedDouble(-1.0)
+                .expectedFloat(-1.0f)
+                .expectedLong(-1)
+                .expectedInt(-1)
+                .expectedShort((short) -1)
+                .expectedCharSequence("-1"),
+            new Parameters(
+                "big decimal value that can be represented in all types",
+                BigDecimal.valueOf(-1)
+            )
+                .expectedBigDecimal(BigDecimal.ONE.negate())
+                .expectedBigInteger(BigInteger.ONE.negate())
+                .expectedDouble(-1.0)
+                .expectedFloat(-1.0f)
+                .expectedLong(-1)
+                .expectedInt(-1)
+                .expectedShort((short) -1)
+                .expectedCharSequence("-1"),
+            new Parameters(
                 "number that can be represented only in HugeDecimal",
                 new HugeDecimal("1e100000000000", new NumberReader(Settings.DEFAULTS))
             )
-                .expectedCharSequence("1e100000000000")
+                .expectedCharSequence("1e100000000000"),
+            new Parameters(
+                "error handling",
+                new HugeDecimal("abc", new NumberReader(Settings.DEFAULTS))
+            )
+                .expectedCharSequence("abc")
+            // all expected number types being null means exception expected for each.
         };
     }
 
@@ -86,9 +118,8 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.bigDecimalValue(), parParameters.expectedBigDecimal);
-                } catch (final IOException | JSONException myException) {
-                    throw new JSONException.JSONRuntimeException(myException);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException | IOException
+                        | JSONException myException) {
                     Assert.assertNull(parParameters.expectedBigDecimal);
                 }
             }
@@ -102,9 +133,8 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.bigIntegerValue(), parParameters.expectedBigInteger);
-                } catch (final IOException | JSONException myException) {
-                    throw new JSONException.JSONRuntimeException(myException);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException | IOException
+                        | JSONException myException) {
                     Assert.assertNull(parParameters.expectedBigInteger);
                 }
             }
@@ -118,7 +148,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.doubleValue(), parParameters.expectedDouble);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException myException) {
                     Assert.assertNull(parParameters.expectedDouble);
                 }
             }
@@ -132,7 +162,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(parInput.floatValue(), parParameters.expectedFloat);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException myException) {
                     Assert.assertNull(parParameters.expectedFloat);
                 }
             }
@@ -146,7 +176,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(Long.valueOf(parInput.longValue()), parParameters.expectedLong);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException myException) {
                     Assert.assertNull(parParameters.expectedLong);
                 }
             }
@@ -160,7 +190,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(Integer.valueOf(parInput.intValue()), parParameters.expectedInt);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException myException) {
                     Assert.assertNull(parParameters.expectedInt);
                 }
             }
@@ -174,7 +204,7 @@ public final class HugeDecimalTest {
             public void accept(final HugeDecimal parInput) {
                 try {
                     Assert.assertEquals(Short.valueOf(parInput.shortValue()), parParameters.expectedShort);
-                } catch (final NumberFormatException | ArithmeticException myException) {
+                } catch (final NumberFormatException | ArithmeticException | JSONRuntimeException myException) {
                     Assert.assertNull(parParameters.expectedShort);
                 }
             }
@@ -190,6 +220,17 @@ public final class HugeDecimalTest {
                     parParameters.expectedCharSequence);
             }
         });
+    }
+
+    @Test
+    public void testNumberSequencingAndSerializing() {
+        final HugeDecimal myNumber = new HugeDecimal(123);
+        Assert.assertEquals(myNumber.subSequence(0, 3), "123");
+        Assert.assertEquals(myNumber.subSequence(0, 2), "12");
+
+        final HugeDecimal mySequence = new HugeDecimal("123", new NumberReader(Settings.DEFAULTS));
+        Assert.assertEquals(mySequence.subSequence(0, 3), "123");
+        Assert.assertEquals(mySequence.subSequence(0, 2), "12");
     }
 
     private void testConvert(final Parameters parParameters, final IConsumer<HugeDecimal> parConsumer) {

--- a/src/test/java/com/chelseaurquhart/securejson/IterableInputStreamTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/IterableInputStreamTest.java
@@ -16,15 +16,31 @@
 
 package com.chelseaurquhart.securejson;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 @SuppressWarnings("PMD.CommentRequired")
-public final class IterableCharSequenceTest {
-    private IterableCharSequenceTest() {
+public final class IterableInputStreamTest {
+    private IterableInputStreamTest() {
     }
 
-    @Test(expectedExceptions = NotImplementedException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testRemove() {
-        new IterableCharSequence("").remove();
+        new IterableInputStream(new ByteArrayInputStream(new byte[0])).remove();
+    }
+
+    @Test
+    public void testReadNextChar() throws IOException {
+        try (InputStream myBuffer = new ByteArrayInputStream(new byte[]{'a', 'b'})) {
+            final IterableInputStream myStream = new IterableInputStream(myBuffer);
+            Assert.assertEquals(myStream.readNextChar(), (Character) 'a');
+            Assert.assertEquals(myStream.readNextChar(), (Character) 'b');
+            Assert.assertNull(myStream.readNextChar());
+            Assert.assertNull(myStream.readNextChar());
+        }
     }
 }

--- a/src/test/java/com/chelseaurquhart/securejson/IterableInputStreamTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/IterableInputStreamTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Chelsea Urquhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chelseaurquhart.securejson;
+
+import org.testng.annotations.Test;
+
+@SuppressWarnings("PMD.CommentRequired")
+public final class IterableCharSequenceTest {
+    private IterableCharSequenceTest() {
+    }
+
+    @Test(expectedExceptions = NotImplementedException.class)
+    public void testRemove() {
+        new IterableCharSequence("").remove();
+    }
+}

--- a/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
@@ -21,6 +21,7 @@ import com.chelseaurquhart.securejson.JSONDecodeException.EmptyJSONException;
 import com.chelseaurquhart.securejson.JSONDecodeException.ExtraCharactersException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedJSONException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedListException;
+import com.chelseaurquhart.securejson.JSONDecodeException.MalformedMapException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedStringException;
 import com.chelseaurquhart.securejson.JSONException.JSONRuntimeException;
 
@@ -37,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 
 @SuppressWarnings("PMD.CommentRequired")
 public final class JSONReaderTest {
@@ -83,187 +85,187 @@ public final class JSONReaderTest {
     @DataProvider(name = DATA_PROVIDER_NAME, parallel = true)
     static Object[] dataProvider(final Method parMethod) throws IOException {
         return new Object[]{
-            new Parameters(
+            new Parameters<>(
                 "empty input",
                 "",
                 null,
                 new EmptyJSONException(new PresetIterableCharSequence())
             ),
-            new Parameters(
+            new Parameters<>(
                 "null",
                 "null",
                 null,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "padded null",
                 " null   ",
                 null,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean true",
                 "true",
                 true,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean padded true",
                 "  true  ",
                 true,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean false",
                 "false",
                 false,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean padded false",
                 "   false   ",
                 false,
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean true with suffix",
                 "truemore",
                 false,
                 new InvalidTokenException(new PresetIterableCharSequence(4))
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean true with extra token",
                 "true]",
                 false,
                 new ExtraCharactersException(new PresetIterableCharSequence(4))
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean false with suffix",
                 "falsemore",
                 false,
                 new InvalidTokenException(new PresetIterableCharSequence(5))
             ),
-            new Parameters(
+            new Parameters<>(
                 "boolean false with extra token",
                 "false]",
                 false,
                 new ExtraCharactersException(new PresetIterableCharSequence(5))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list",
                 "[]",
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF8 BOM",
                 new byte[]{(byte) 0xef, (byte) 0xbb, (byte) 0xbf, '[', ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 BOM big-endian",
                 new byte[]{(byte) 0xfe, (byte) 0xff, 0, '[', 0, ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 NO BOM big-endian",
                 new byte[]{0, '[', 0, ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF8 with BOM",
                 new byte[]{0, '[', ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 BOM little-endian",
                 new byte[]{(byte) 0xff, (byte) 0xfe, '[', 0, ']', 0},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 NO BOM little-endian",
                 new byte[]{'[', 0, ']', 0},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 BOM big-endian",
                 new byte[]{0, 0, (byte) 0xfe, (byte) 0xff, 0, 0, 0, '[', 0, 0, 0, ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 NO BOM big-endian",
                 new byte[]{0, 0, 0, '[', 0, 0, 0, ']'},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 NO BOM big-endian, malformed",
                 new byte[]{0, 0, 0, '[', 0, 0, ']'},
                 new ArrayList<>(),
                 new InvalidTokenException(new PresetIterableCharSequence(6))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 BOM little-endian",
                 new byte[]{(byte) 0xff, (byte) 0xfe, 0, 0, '[', 0, 0, 0, ']', 0, 0, 0},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 NO BOM little-endian",
                 new byte[]{'[', 0, 0, 0, ']', 0, 0, 0},
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF8 BOM, extra token",
                 new byte[]{(byte) 0xef, (byte) 0xbb, (byte) 0xbf, '[', ']', ']'},
                 new ArrayList<>(),
                 new ExtraCharactersException(new PresetIterableCharSequence(5))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 BOM big-endian, extra token",
                 new byte[]{(byte) 0xfe, (byte) 0xff, 0, '[', 0, ']', 0, ']'},
                 new ArrayList<>(),
                 new ExtraCharactersException(new PresetIterableCharSequence(7))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF16 BOM little-endian, extra token",
                 new byte[]{(byte) 0xff, (byte) 0xfe, '[', 0, ']', 0, ']', 0},
                 new ArrayList<>(),
                 new ExtraCharactersException(new PresetIterableCharSequence(7))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 BOM big-endian, extra token",
                 new byte[]{0, 0, (byte) 0xfe, (byte) 0xff, 0, 0, 0, '[', 0, 0, 0, ']', 0, 0, 0, ']'},
                 new ArrayList<>(),
                 new ExtraCharactersException(new PresetIterableCharSequence(15))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list, UTF32 BOM little-endian, extra token",
                 new byte[]{(byte) 0xff, (byte) 0xfe, 0, 0, '[', 0, 0, 0, ']', 0, 0, 0, ']', 0, 0, 0},
                 new ArrayList<>(),
                 new ExtraCharactersException(new PresetIterableCharSequence(15))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list padded",
                 "  [   ]  ",
                 new ArrayList<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list extra token",
                 "[]]",
                 false,
                 new ExtraCharactersException(new PresetIterableCharSequence(2))
             ),
-            new Parameters(
+            new Parameters<>(
                 "list with numbers",
                 "  [1,4 ,  -3,1.14159]  ",
                 Arrays.asList(
@@ -274,55 +276,85 @@ public final class JSONReaderTest {
                 ),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "list with trailing comma",
                 "  [1,4 ,]  ",
                 null,
                 new InvalidTokenException(new PresetIterableCharSequence(8))
             ),
-            new Parameters(
+            new Parameters<>(
                 "list with missing closing bracket",
                 "  [1,4  ",
                 null,
                 new MalformedJSONException(new PresetIterableCharSequence(8))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty list with missing closing bracket",
                 "  [",
                 null,
                 new MalformedListException(new PresetIterableCharSequence(3))
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty padded list with missing closing bracket",
                 "  [  ",
                 null,
                 new MalformedListException(new PresetIterableCharSequence(5))
             ),
-            new Parameters(
+            new Parameters<>(
+                "empty map with missing closing brace",
+                "  {",
+                null,
+                new MalformedMapException(new PresetIterableCharSequence(3))
+            ),
+            new Parameters<>(
+                "empty padded map with missing closing brace",
+                "  {  ",
+                null,
+                new MalformedMapException(new PresetIterableCharSequence(5))
+            ),
+            new Parameters<>(
+                "nested lists",
+                "  [[1,2],3]  ",
+                new ArrayList<Object>() {{
+                        add(new ArrayList<Integer>() {{
+                                add(1);
+                                add(2);
+                            }});
+                        add(3);
+                    }},
+                null
+            ),
+            new Parameters<>(
+                "nested lists malformed comma",
+                "  [[1,2],  ,]  ",
+                null,
+                new InvalidTokenException(new PresetIterableCharSequence(11))
+            ),
+            new Parameters<>(
                 "invalid token",
                 "***",
                 null,
                 new InvalidTokenException(new PresetIterableCharSequence())
             ),
-            new Parameters(
+            new Parameters<>(
                 "empty map",
                 "{}",
                 new HashMap<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with padding",
                 "  {  }  ",
                 new HashMap<>(),
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with numeric keys",
                 "{1:\"test\"}",
                 null,
                 new MalformedStringException(new PresetIterableCharSequence(1))
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with string:string",
                 "{\"1\":\"test\"}",
                 new HashMap<CharSequence, Object>() {{
@@ -330,7 +362,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with string:int",
                 "{\"1\":123}",
                 new HashMap<CharSequence, Object>() {{
@@ -338,7 +370,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with string:null",
                 "{\"1\":null}",
                 new HashMap<CharSequence, Object>() {{
@@ -346,7 +378,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with string:bool",
                 "{\"1\":true}",
                 new HashMap<CharSequence, Object>() {{
@@ -354,7 +386,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "map with string:bool padded",
                 "{\"1\"   :    true}",
                 new HashMap<CharSequence, Object>() {{
@@ -362,7 +394,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "much nesting",
                 "{\"1\"   :    [1,2,3],\"2\":[false,{\"22\":\"456\"}]}",
                 new HashMap<CharSequence, Object>() {{
@@ -373,7 +405,7 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "spaces around comma in map",
                 "{\"asd\":\"sdf\"   ,  \"dfg\":\"fgh\"}",
                 new HashMap<CharSequence, Object>() {{
@@ -382,12 +414,23 @@ public final class JSONReaderTest {
                     }},
                 null
             ),
-            new Parameters(
+            new Parameters<>(
                 "spaces around comma in list",
                 "[\"abc\"  ,  \"def\"]",
                 Arrays.asList("abc", "def"),
                 null
             ),
+            new Parameters<Deserializable>(
+                "custom object",
+                "[\"abc\"  ,  \"def\"]",
+                new Deserializable() {{
+                        input = new LinkedList<Object>() {{
+                                add("abc");
+                                add("def");
+                            }};
+                    }},
+                null
+            ).clazz(Deserializable.class),
         };
     }
 
@@ -443,14 +486,15 @@ public final class JSONReaderTest {
         }
     }
 
-    static class Parameters {
+    static class Parameters<T> {
         private String testName;
         private byte[] inputBytes;
         private CharSequence inputString;
-        private Object expected;
+        private T expected;
+        private Class<T> expectedClass;
         private Exception expectedException;
 
-        Parameters(final String parTestName, final byte[] parInputBytes, final Object parExpected,
+        Parameters(final String parTestName, final byte[] parInputBytes, final T parExpected,
                    final Exception parExpectedException) {
             testName = parTestName;
             inputBytes = parInputBytes;
@@ -458,7 +502,7 @@ public final class JSONReaderTest {
             expectedException = parExpectedException;
         }
 
-        Parameters(final String parTestName, final CharSequence parInputString, final Object parExpected,
+        Parameters(final String parTestName, final CharSequence parInputString, final T parExpected,
                    final Exception parExpectedException) {
             testName = parTestName;
             final ManagedSecureCharBuffer mySecureBuffer = new ManagedSecureCharBuffer(parInputString.length(),
@@ -467,6 +511,12 @@ public final class JSONReaderTest {
             inputString = mySecureBuffer;
             expected = parExpected;
             expectedException = parExpectedException;
+        }
+
+        Parameters<T> clazz(final Class<T> parClass) {
+            expectedClass = parClass;
+
+            return this;
         }
 
         CharSequence getInputString() {
@@ -481,11 +531,7 @@ public final class JSONReaderTest {
             return inputString;
         }
 
-        public String getTestName() {
-            return testName;
-        }
-
-        public byte[] getInputBytes() {
+        byte[] getInputBytes() {
             return inputBytes;
         }
 
@@ -493,13 +539,34 @@ public final class JSONReaderTest {
             return expected;
         }
 
-        public Exception getExpectedException() {
+        Exception getExpectedException() {
             return expectedException;
         }
 
         @Override
         public String toString() {
             return testName;
+        }
+
+        Class<T> getExpectedClass() {
+            return expectedClass;
+        }
+    }
+
+    static class Deserializable implements IJSONAware {
+        transient Object input;
+
+        private Deserializable() {
+        }
+
+        @Override
+        public void fromJSONable(final Object parInput) {
+            input = parInput;
+        }
+
+        @Override
+        public Object toJSONable() {
+            return input;
         }
     }
 }

--- a/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/JSONReaderTest.java
@@ -17,6 +17,7 @@
 package com.chelseaurquhart.securejson;
 
 import com.chelseaurquhart.securejson.JSONDecodeException.InvalidTokenException;
+import com.chelseaurquhart.securejson.JSONDecodeException.EmptyJSONException;
 import com.chelseaurquhart.securejson.JSONDecodeException.ExtraCharactersException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedJSONException;
 import com.chelseaurquhart.securejson.JSONDecodeException.MalformedListException;
@@ -82,6 +83,12 @@ public final class JSONReaderTest {
     @DataProvider(name = DATA_PROVIDER_NAME, parallel = true)
     static Object[] dataProvider(final Method parMethod) throws IOException {
         return new Object[]{
+            new Parameters(
+                "empty input",
+                "",
+                null,
+                new EmptyJSONException(new PresetIterableCharSequence())
+            ),
             new Parameters(
                 "null",
                 "null",

--- a/src/test/java/com/chelseaurquhart/securejson/SecureJSONTest.java
+++ b/src/test/java/com/chelseaurquhart/securejson/SecureJSONTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 @SuppressWarnings("PMD.CommentRequired")
 public final class SecureJSONTest {
     @Test(dataProviderClass = JSONReaderTest.class, dataProvider = JSONReaderTest.DATA_PROVIDER_NAME)
+    @SuppressWarnings("unchecked")
     public void testReadString(final JSONReaderTest.Parameters parParameters) {
         try {
             new SecureJSON().fromJSON(parParameters.getInputString(), new IConsumer<Object>() {
@@ -40,7 +41,7 @@ public final class SecureJSONTest {
                     Assert.assertEquals(StringUtil.deepCharSequenceToString(parParameters.getExpected()),
                         StringUtil.deepCharSequenceToString(parInput));
                 }
-            });
+            }, parParameters.getExpectedClass());
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
         } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
@@ -48,6 +49,7 @@ public final class SecureJSONTest {
     }
 
     @Test(dataProviderClass = JSONReaderTest.class, dataProvider = JSONReaderTest.DATA_PROVIDER_NAME)
+    @SuppressWarnings("unchecked")
     public void testReadStream(final JSONReaderTest.Parameters parParameters) {
         final InputStream myInputStream = JSONReaderTest.inputToStream(
             parParameters.getInputString(), parParameters.getInputBytes());
@@ -59,7 +61,7 @@ public final class SecureJSONTest {
                     Assert.assertEquals(StringUtil.deepCharSequenceToString(parParameters.getExpected()),
                         StringUtil.deepCharSequenceToString(parInput));
                 }
-            });
+            }, parParameters.getExpectedClass());
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
         } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
@@ -67,6 +69,7 @@ public final class SecureJSONTest {
     }
 
     @Test(dataProviderClass = JSONReaderTest.class, dataProvider = JSONReaderTest.DATA_PROVIDER_NAME)
+    @SuppressWarnings("unchecked")
     public void testReadBytes(final JSONReaderTest.Parameters parParameters) {
         try {
             final byte[] myBytes;
@@ -76,13 +79,14 @@ public final class SecureJSONTest {
             } else {
                 myBytes = parParameters.getInputBytes();
             }
+
             new SecureJSON().fromJSON(myBytes, new IConsumer<Object>() {
                 @Override
                 public void accept(final Object parInput) {
                     Assert.assertEquals(StringUtil.deepCharSequenceToString(parParameters.getExpected()),
                         StringUtil.deepCharSequenceToString(parInput));
                 }
-            });
+            }, parParameters.getExpectedClass());
             Assert.assertNull(parParameters.getExpectedException(), "Expected exception was not thrown");
         } catch (final JSONDecodeException | JSONRuntimeException myException) {
             checkException(parParameters, myException);
@@ -103,7 +107,7 @@ public final class SecureJSONTest {
             @Override
             public void accept(final CharSequence parInput) {
                 Assert.assertEquals(StringUtil.charSequenceToString(parInput),
-                    StringUtil.charSequenceToString(parParameters.getExpected()));
+                    StringUtil.charSequenceToString(parParameters.getSecureJSONExpected()));
             }
         });
     }
@@ -114,7 +118,7 @@ public final class SecureJSONTest {
         final ByteArrayOutputStream myOutputStream = new ByteArrayOutputStream();
         new SecureJSON().toJSON(parParameters.getInputObject(), myOutputStream);
         Assert.assertEquals(StringUtil.charSequenceToString(myOutputStream.toString(StandardCharsets.UTF_8.name())),
-            StringUtil.charSequenceToString(parParameters.getExpected()));
+            StringUtil.charSequenceToString(parParameters.getSecureJSONExpected()));
     }
 
     @Test(dataProviderClass = JSONWriterTest.class, dataProvider = JSONWriterTest.DATA_PROVIDER_NAME)
@@ -124,7 +128,7 @@ public final class SecureJSONTest {
             @Override
             public void accept(final byte[] parInput) {
                 Assert.assertEquals(StandardCharsets.UTF_8.decode(ByteBuffer.wrap(parInput)).toString(),
-                    StringUtil.charSequenceToString(parParameters.getExpected()));
+                    StringUtil.charSequenceToString(parParameters.getSecureJSONExpected()));
             }
         });
     }

--- a/src/test/java/com/chelseaurquhart/securejson/StringProvider.java
+++ b/src/test/java/com/chelseaurquhart/securejson/StringProvider.java
@@ -16,8 +16,13 @@
 
 package com.chelseaurquhart.securejson;
 
+
+import com.chelseaurquhart.securejson.JSONDecodeException.MalformedStringException;
+import com.chelseaurquhart.securejson.JSONDecodeException.MalformedUnicodeValueException;
+
 import org.testng.annotations.DataProvider;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 
 /**
@@ -35,9 +40,10 @@ public final class StringProvider {
      *
      * @param parMethod The method being executed.
      * @return A collection of parameters.
+     * @throws IOException On message read failure.
      */
     @DataProvider(name = DATA_PROVIDER_NAME, parallel = true)
-    public static Object[] dataProvider(final Method parMethod) {
+    public static Object[] dataProvider(final Method parMethod) throws IOException {
         return new Object[]{
             buildParameters(
                 "simple string",
@@ -64,6 +70,18 @@ public final class StringProvider {
                 "\"\\u1234\\u5678\\uabcd\"",
                 "\u1234\u5678\uabcd"
             ),
+            buildParameters(
+                "string with invalid escape characters",
+                "\"abc\\a\"",
+                null
+            )
+                .exception(new MalformedStringException(new PresetIterableCharSequence(5))),
+            buildParameters(
+                "string with bad unicode escape sequence",
+                "\"abc\\u123\"",
+                null
+            )
+                .exception(new MalformedUnicodeValueException(new PresetIterableCharSequence(9))),
         };
     }
 


### PR DESCRIPTION
- properly configure java 7 if JRE is available (requires JRE to be installed and I have not decided yet if I will do that in the CI, seeing as I don't publish to Maven from CI)
- improve utf8 with bom detection
- several fixes to counter increments despite error
- support both char sequences and numbers in toJSONable
- change HugeDecimal to not implement IJSONSerializeAware
- move empty json detection
- remove some unused code
- support for objects that implement IJSONSerializeAware in StringUtil
- a significant number of unit test additions and improvements